### PR TITLE
Fixed QCustomPlot linking on KDE Neon

### DIFF
--- a/examples/dist_QCustomPlot/CMakeLists.txt
+++ b/examples/dist_QCustomPlot/CMakeLists.txt
@@ -4,4 +4,4 @@ find_package(Qt5 REQUIRED COMPONENTS Widgets)
 find_package(QCustomPlot REQUIRED)
 
 add_executable(dist_QCustomPlot dist_QCustomPlot.cpp)
-target_link_libraries(dist_QCustomPlot PRIVATE ALFI Qt5::Widgets ${QCustomPlot_LIBRARIES})
+target_link_libraries(dist_QCustomPlot PRIVATE ALFI Qt5::Widgets QCustomPlot)


### PR DESCRIPTION
### Types of changes
- Bug fix

Related: #1

### Description
Replaced `${QCustomPlot_LIBRARIES}` with `QCustomPlot` as the previous approach does not work on KDE Neon.
This solution should work on other platforms as well.