### PR TITLE
refactor: Replaced manual computation of differences with `diff` function

### DIFF
--- a/ALFI/ALFI/spline/cubic.h
+++ b/ALFI/ALFI/spline/cubic.h
@@ -69,11 +69,7 @@ namespace alfi::spline {
 					return util::spline::simple_spline<Number,Container>(X, Y, 3);
 				}
 
-				Container<Number> dX(n - 1), dY(n - 1);
-				for (SizeT i = 0; i < n - 1; ++i) {
-					dX[i] = X[i+1] - X[i];
-					dY[i] = Y[i+1] - Y[i];
-				}
+				const Container<Number> dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
 
 				Container<Number> B(n);
 				B[0] = B[n-1] = 0;
@@ -118,11 +114,7 @@ namespace alfi::spline {
 					return util::spline::simple_spline<Number,Container>(X, Y, 3);
 				}
 
-				Container<Number> dX(n - 1), dY(n - 1);
-				for (SizeT i = 0; i < n - 1; ++i) {
-					dX[i] = X[i+1] - X[i];
-					dY[i] = Y[i+1] - Y[i];
-				}
+				const Container<Number> dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
 
 				const auto big_denominator = dX[n-2] * (dX[n-3] + dX[n-2]) * (2*dX[n-3] + dX[n-2]);
 
@@ -183,11 +175,7 @@ namespace alfi::spline {
 					return util::spline::simple_spline<Number,Container>(X, Y, 3);
 				}
 
-				Container<Number> dX(n - 1), dY(n - 1);
-				for (SizeT i = 0; i < n - 1; ++i) {
-					dX[i] = X[i+1] - X[i];
-					dY[i] = Y[i+1] - Y[i];
-				}
+				const Container<Number> dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
 
 				Container<Number> B(n);
 				if (n == 3) {
@@ -252,11 +240,7 @@ namespace alfi::spline {
 					return util::spline::simple_spline<Number,Container>(X, Y, 3);
 				}
 
-				Container<Number> dX(n - 1), dY(n - 1);
-				for (SizeT i = 0; i < n - 1; ++i) {
-					dX[i] = X[i+1] - X[i];
-					dY[i] = Y[i+1] - Y[i];
-				}
+				const Container<Number> dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
 
 				{ // first four points
 					const auto h1 = dX[0], h2 = dX[1];
@@ -300,11 +284,7 @@ namespace alfi::spline {
 					return util::spline::simple_spline<Number,Container>(X, Y, 3);
 				}
 
-				Container<Number> dX(n - 1), dY(n - 1);
-				for (SizeT i = 0; i < n - 1; ++i) {
-					dX[i] = X[i+1] - X[i];
-					dY[i] = Y[i+1] - Y[i];
-				}
+				const Container<Number> dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
 
 				{ // last four points
 					const auto h1 = dX[n-4], h2 = dX[n-3];

--- a/ALFI/ALFI/util/arrays.h
+++ b/ALFI/ALFI/util/arrays.h
@@ -6,7 +6,7 @@
 
 namespace alfi::util::arrays {
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
-	Container<Number> sum(const Container<Number>& container1, const Container<Number>& container2) {
+	Container<Number> add(const Container<Number>& container1, const Container<Number>& container2) {
 		if (container1.size() != container2.size()) {
 			std::cerr << "Error in function " << __FUNCTION__
 					  << ": Vectors container1 (of size " << container1.size()
@@ -23,7 +23,7 @@ namespace alfi::util::arrays {
 	}
 
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
-	Container<Number> diff(const Container<Number>& container1, const Container<Number>& container2) {
+	Container<Number> sub(const Container<Number>& container1, const Container<Number>& container2) {
 		if (container1.size() != container2.size()) {
 			std::cerr << "Error in function " << __FUNCTION__
 					  << ": Vectors container1 (of size " << container1.size()
@@ -35,6 +35,18 @@ namespace alfi::util::arrays {
 		Container<Number> result(n);
 		for (std::remove_const_t<decltype(n)> i = 0; i < n; ++i) {
 			result[i] = container1[i] - container2[i];
+		}
+		return result;
+	}
+
+	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	Container<Number> diff(const auto& container) {
+		if (container.empty()) {
+			return {};
+		}
+		Container<Number> result(container.size() - 1);
+		for (SizeT i = 0; i < result.size(); ++i) {
+			result[i] = container[i+1] - container[i];
 		}
 		return result;
 	}


### PR DESCRIPTION
### Types of changes
- Refactoring, reformatting, cleanup

Related: #7

### Description
- Renamed `diff` to `sub` and `sum` to `add` in `util::arrays::`.
- Introduced a new `util::arrays::diff` function to compute differences between adjacent elements.
- Replaced manual calculation of differences for arrays `X` and `Y` in `cubic.h` with the `util::arrays::diff` function.