### PR TITLE
Changed the type of spline types from `enum class` to `std::variant`

### DIFF
--- a/ALFI/ALFI/spline/cubic.h
+++ b/ALFI/ALFI/spline/cubic.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <algorithm>
 #include <iostream>
 #include <cmath>
+#include <variant>
 
 #include "../config.h"
 #include "../util/arrays.h"
@@ -12,44 +14,52 @@ namespace alfi::spline {
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
 	class CubicSpline {
 	public:
-		enum class Type {
+		struct Types final {
 			/**
 			 * Second derivatives at the end points are equal to zero.\n
 			 * Has minimum curvature of all interpolating functions and is most stable.\n
 			 */
-			NATURAL,
+			struct Natural final {};
 			/**
 			 * The third derivative is continuous at the second and second-to-last points.
 			 * In this way, the second and second-to-last points "cease to be knot points".
 			 */
-			NOT_A_KNOT,
+			struct NotAKnot final {};
 			/**
 			 * The first and second derivatives at the end points are equal.
 			 */
-			PERIODIC,
+			struct Periodic final {};
 			/**
 			 * A cubic curve is constructed through the first four points. Then each subsequent segment is built sequentially.\n
 			 * This is equivalent to the condition of continuity of the third derivative at the second and third points.\n
 			 * In this way, the second and third points "cease to be knot points".
 			 */
-			NOT_A_KNOT_START,
+			struct NotAKnotStart final {};
 			/**
 			 * A cubic curve is constructed through the last four points. Then each previous segment is built sequentially.\n
 			 * This is equivalent to the condition of continuity of the third derivative at the third-to-last and second-to-last points.\n
 			 * In this way, the third-to-last and second-to-last points "cease to be knot points".
 			 */
-			NOT_A_KNOT_END,
+			struct NotAKnotEnd final {};
 			/**
-			 * The arithmetic mean_array between NOT_A_KNOT_START and NOT_A_KNOT_END.
+			 * The arithmetic mean_array between NotAKnotStart and NotAKnotEnd.
 			 */
-			SEMI_NOT_A_KNOT,
-
-			Default = NATURAL,
+			struct SemiNotAKnot final {};
+			using Default = Natural;
 		};
 
-		static Container<Number> compute_coeffs(const auto& X, const auto& Y, Type type = Type::Default) {
+		using Type = std::variant<typename Types::Natural,
+								  typename Types::NotAKnot,
+								  typename Types::Periodic,
+								  typename Types::NotAKnotStart,
+								  typename Types::NotAKnotEnd,
+								  typename Types::SemiNotAKnot>;
+
+		static Container<Number> compute_coeffs(const auto& X, const auto& Y, Type type = typename Types::Default{}) {
+			constexpr auto FUNCTION = __FUNCTION__;
+
 			if (X.size() != Y.size()) {
-				std::cerr << "Error in function " << __FUNCTION__
+				std::cerr << "Error in function " << FUNCTION
 						  << ": Vectors X (of size " << X.size()
 						  << ") and Y (of size " << Y.size()
 						  << ") are not the same size. Returning an empty array..." << std::endl;
@@ -64,274 +74,279 @@ namespace alfi::spline {
 
 			Container<Number> coeffs(4 * (n - 1));
 
-			if (type == Type::NATURAL) {
-				if (n <= 2) {
-					return util::spline::simple_spline<Number,Container>(X, Y, 3);
-				}
+			std::visit(util::misc::overload{
+				[&](const typename Types::Natural&) {
+					if (n <= 2) {
+						coeffs = util::spline::simple_spline<Number,Container>(X, Y, 3);
+						return;
+					}
 
-				const Container<Number> dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
+					const Container<Number> dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
 
-				Container<Number> B(n);
-				B[0] = B[n-1] = 0;
-				// Tridiagonal matrix algorithm
-				Container<Number> diagonal(n - 2), right(n - 2);
-				for (SizeT i = 0; i < n - 2; ++i) {
-					diagonal[i] = 2 * (dX[i] + dX[i+1]);
-					right[i] = 3 * (dY[i+1] / dX[i+1] - dY[i] / dX[i]);
-				}
-				// Forward pass
-				for (SizeT i = 1; i < n - 2; ++i) {
-					const auto m = dX[i] / diagonal[i-1];
-					diagonal[i] -= m * dX[i];
-					right[i] -= m * right[i-1];
-				}
-				// Backward pass
-				B[n-2] = right[n-3] / diagonal[n-3];
-				for (SizeT i = n - 3; i >= 1; --i) {
-					B[i] = (right[i-1] - dX[i] * B[i+1]) / diagonal[i-1];
-				}
+					Container<Number> B(n);
+					B[0] = B[n-1] = 0;
 
-				Container<Number> A(n - 1);
-				for (SizeT i = 0; i < A.size(); ++i) {
-					A[i] = (B[i+1] - B[i]) / (3*dX[i]);
-				}
-
-				Container<Number> C(n - 1);
-				for (SizeT i = 0; i < C.size(); ++i) {
-					C[i] = dY[i] / dX[i] - dX[i] * ((2*B[i] + B[i+1]) / 3);
-				}
-
-				// const auto D = Y; - no need to create extra array
-
-				for (SizeT i = 0, index = 0; i < n - 1; ++i) {
-					coeffs[index++] = A[i];
-					coeffs[index++] = B[i];
-					coeffs[index++] = C[i];
-					coeffs[index++] = Y[i]; // = D[i];
-				}
-			} else if (type == Type::NOT_A_KNOT) {
-				if (n <= 4) {
-					return util::spline::simple_spline<Number,Container>(X, Y, 3);
-				}
-
-				const Container<Number> dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
-
-				const auto big_denominator = dX[n-2] * (dX[n-3] + dX[n-2]) * (2*dX[n-3] + dX[n-2]);
-
-				Container<Number> B(n - 1);
-				// Tridiagonal matrix algorithm
-				Container<Number> diagonal(n - 3), right(n - 3);
-				diagonal[0] = ((dX[0] + dX[1]) * (dX[0] + 2 * dX[1])) / dX[1];
-				for (SizeT i = 1; i < n - 4; ++i) {
-					diagonal[i] = 2 * (dX[i] + dX[i+1]);
-				}
-				diagonal[n-4] = 2 * dX[n-4] + 3 * dX[n-3] * (1 - dX[n-3] / (2 * dX[n-3] + dX[n-2]));
-				for (SizeT i = 0; i < n - 4; ++i) {
-					right[i] = 3 * (dY[i+1] / dX[i+1] - dY[i] / dX[i]);
-				}
-				right[n-4] = 3 * (dY[n-3]/dX[n-3] - dY[n-4]/dX[n-4]) - (3*dX[n-3]*(dY[n-2]*dX[n-3] - dY[n-3]*dX[n-2])) / big_denominator;
-				// Forward pass
-				diagonal[1] -= dX[1] / diagonal[0] * (dX[1] - (dX[0] * dX[0]) / dX[1]);
-				right[1] -= dX[1] / diagonal[0] * right[0];
-				for (SizeT i = 2; i < n - 3; ++i) {
-					const auto m = dX[i] / diagonal[i-1];
-					diagonal[i] -= m * dX[i];
-					right[i] -= m * right[i-1];
-				}
-				// Backward pass
-				B[n-3] = right[n-4] / diagonal[n-4];
-				for (SizeT i = n - 4; i >= 2; --i) {
-					B[i] = (right[i-1] - dX[i] * B[i+1]) / diagonal[i-1];
-				}
-				B[1] = (right[0] - (dX[1] - (dX[0] * dX[0]) / dX[1]) * B[2]) / diagonal[0];
-
-				B[n-2] = (dX[n-2]*(B[n-3]*(dX[n-2]*dX[n-2] - dX[n-3]*dX[n-3]) - 3*dY[n-3]) + 3*dX[n-3]*dY[n-2]) / big_denominator;
-
-				Container<Number> A(n - 1);
-				for (SizeT i = 1; i < A.size() - 1; ++i) {
-					A[i] = (B[i+1] - B[i]) / (3*dX[i]);
-				}
-				A[0] = A[1];
-				A[n-2] = A[n-3];
-
-				B[0] = B[1] - 3 * A[0] * dX[0];
-
-				Container<Number> C(n - 1);
-				for (SizeT i = 0; i < C.size() - 1; ++i) {
-					C[i] = dY[i] / dX[i] - dX[i] * ((2*B[i] + B[i+1]) / 3);
-				}
-				C[n-2] = dY[n-2] / dX[n-2] - A[n-2] * dX[n-2] * dX[n-2] - B[n-2] * dX[n-2];
-
-				// const auto D = Y; - no need to create extra array
-
-				for (SizeT i = 0, index = 0; i < n - 1; ++i) {
-					coeffs[index++] = A[i];
-					coeffs[index++] = B[i];
-					coeffs[index++] = C[i];
-					coeffs[index++] = Y[i]; // = D[i];
-				}
-			} else if (type == Type::PERIODIC) {
-				if (n <= 2) {
-					return util::spline::simple_spline<Number,Container>(X, Y, 3);
-				}
-
-				const Container<Number> dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
-
-				Container<Number> B(n);
-				if (n == 3) {
-					B[0] = 3 * (dY[0] / dX[0] - dY[1] / dX[1]) / (dX[0] + dX[1]);
-					B[1] = -B[0];
-					B[2] = B[0];
-				} else {
-					Container<Number> diag(n - 1), right(n - 1);
+					Container<Number> diagonal(n - 2), right(n - 2);
 					for (SizeT i = 0; i < n - 2; ++i) {
-						diag[i] = 2 * (dX[i] + dX[i+1]);
+						diagonal[i] = 2 * (dX[i] + dX[i+1]);
 						right[i] = 3 * (dY[i+1] / dX[i+1] - dY[i] / dX[i]);
 					}
-					diag[n-2] = 2 * (dX[n-2] + dX[0]);
-					right[n-2] = 3 * (dY[0]/dX[0] - dY[n-2]/dX[n-2]);
 
-					Container<Number> last_row(n - 2), last_col(n - 2);
-					last_row[0] = last_col[0] = dX[0];
-					for (SizeT i = 1; i < n - 3; ++i) {
-						last_row[i] = last_col[i] = 0;
+					for (SizeT i = 1; i < n - 2; ++i) {
+						const auto m = dX[i] / diagonal[i-1];
+						diagonal[i] -= m * dX[i];
+						right[i] -= m * right[i-1];
 					}
-					last_row[n-3] = last_col[n-3] = dX[n-2];
 
-					for (SizeT i = 0; i < n - 3; ++i) {
-						const auto m1 = dX[i+1] / diag[i];
-						diag[i+1] -= m1 * dX[i+1];
-						last_col[i+1] -= m1 * last_col[i];
-						right[i+1] -= m1 * right[i];
-						const auto m2 = last_row[i] / diag[i];
-						last_row[i+1] -= m2 * dX[i+1];
-						diag[n-2] -= m2 * last_col[i];
-						right[n-2] -= m2 * right[i];
-					}
-					diag[n-2] -= last_row[n-3] / diag[n-3] * last_col[n-3];
-					right[n-2] -= last_row[n-3] / diag[n-3] * right[n-3];
-
-					B[n-1] = right[n-2] / diag[n-2];
-					B[n-2] = (right[n-3] - last_col[n-3] * B[n-1]) / diag[n-3];
+					B[n-2] = right[n-3] / diagonal[n-3];
 					for (SizeT i = n - 3; i >= 1; --i) {
-						B[i] = (right[i-1] - dX[i]*B[i+1] - last_col[i-1]*B[n-1]) / diag[i-1];
-					}
-					B[0] = B[n-1];
-				}
-
-				Container<Number> A(n - 1);
-				for (SizeT i = 0; i < A.size(); ++i) {
-					A[i] = (B[i+1] - B[i]) / (3*dX[i]);
-				}
-
-				Container<Number> C(n - 1);
-				for (SizeT i = 0; i < C.size(); ++i) {
-					C[i] = dY[i] / dX[i] - dX[i] * ((2*B[i] + B[i+1]) / 3);
-				}
-
-				for (SizeT i = 0, index = 0; i < n - 1; ++i) {
-					coeffs[index++] = A[i];
-					coeffs[index++] = B[i];
-					coeffs[index++] = C[i];
-					coeffs[index++] = Y[i]; // = D[i];
-				}
-			} else if (type == Type::NOT_A_KNOT_START) {
-				if (n <= 4) {
-					return util::spline::simple_spline<Number,Container>(X, Y, 3);
-				}
-
-				const Container<Number> dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
-
-				{ // first four points
-					const auto h1 = dX[0], h2 = dX[1];
-					const auto h12 = X[2]-X[0], h13 = X[3]-X[0];
-					const auto d1 = Y[1]-Y[0], d12 = Y[2]-Y[0], d13 = Y[3]-Y[0];
-
-					const auto abc = util::linalg::linsolve(
-						{{std::pow(h1, 3), std::pow(h1, 2), h1},
-							{std::pow(h12, 3), std::pow(h12, 2), h12},
-							{std::pow(h13, 3), std::pow(h13, 2), h13}},
-						{d1, d12, d13});
-					if (abc.empty()) {
-						std::cerr << "Error in function " << __FUNCTION__ << ": Could not compute. Returning an empty array..." << std::endl;
-						return {};
+						B[i] = (right[i-1] - dX[i] * B[i+1]) / diagonal[i-1];
 					}
 
-					const auto a = abc[0], b = abc[1], c = abc[2];
-
-					coeffs[0] = a; // a1
-					coeffs[1] = b; // b1
-					coeffs[2] = c; // c1
-					coeffs[3] = Y[0]; // d1
-					coeffs[4] = a; // a2
-					coeffs[5] = 3 * a * h1 + b; // b2
-					coeffs[6] = 3 * a * std::pow(h1, 2) + 2 * b * h1 + c; // c2
-					coeffs[7] = Y[1]; // d2
-					coeffs[8] = a; // a3
-					coeffs[9] = 3 * a * h2 + coeffs[5]; // b3
-					coeffs[10] = 3 * a * std::pow(h2, 2) + 2 * coeffs[5] * h2 + coeffs[6]; // c3
-					coeffs[11] = Y[2]; // d3
-				}
-
-				for (SizeT i = 3; i < n - 1; ++i) {
-					coeffs[4*i+3] = Y[i];
-					coeffs[4*i+2] = 3 * coeffs[4*(i-1)] * pow(dX[i-1], 2) + 2 * coeffs[4*(i-1)+1] * dX[i-1] + coeffs[4*(i-1)+2];
-					coeffs[4*i+1] = 3 * coeffs[4*(i-1)] * dX[i-1] + coeffs[4*(i-1)+1];
-					coeffs[4*i] = (dY[i]/dX[i] - coeffs[4*i+1] * dX[i] - coeffs[4*i+2]) / pow(dX[i], 2);
-				}
-			} else if (type == Type::NOT_A_KNOT_END) {
-				if (n <= 4) {
-					return util::spline::simple_spline<Number,Container>(X, Y, 3);
-				}
-
-				const Container<Number> dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
-
-				{ // last four points
-					const auto h1 = dX[n-4], h2 = dX[n-3];
-					const auto h12 = X[n-2]-X[n-4], h13 = X[n-1]-X[n-4];
-					const auto d1 = dY[n-4], d12 = Y[n-2] - Y[n-4], d13 = Y[n-1] - Y[n-4];
-
-					const auto abc = util::linalg::linsolve(
-						{{std::pow(h1, 3), std::pow(h1, 2), h1},
-							{std::pow(h12, 3), std::pow(h12, 2), h12},
-							{std::pow(h13, 3), std::pow(h13, 2), h13}},
-						{d1, d12, d13});
-					if (abc.empty()) {
-						std::cerr << "Error in function " << __FUNCTION__ << ": Could not compute. Returning an empty array..." << std::endl;
-						return {};
+					Container<Number> A(n - 1);
+					for (SizeT i = 0; i < A.size(); ++i) {
+						A[i] = (B[i+1] - B[i]) / (3*dX[i]);
 					}
 
-					const auto a = abc[0], b = abc[1], c = abc[2];
+					Container<Number> C(n - 1);
+					for (SizeT i = 0; i < C.size(); ++i) {
+						C[i] = dY[i] / dX[i] - dX[i] * ((2*B[i] + B[i+1]) / 3);
+					}
 
-					coeffs[4*(n-4)] = a; // an-3
-					coeffs[4*(n-4)+1] = b; // bn-3
-					coeffs[4*(n-4)+2] = c; // cn-3
-					coeffs[4*(n-4)+3] = Y[n-4]; // dn-3
-					coeffs[4*(n-3)] = a; // an-2
-					coeffs[4*(n-3)+1] = 3 * a * h1 + b; // bn-2
-					coeffs[4*(n-3)+2] = 3 * a * std::pow(h1, 2) + 2 * b * h1 + c; // cn-2
-					coeffs[4*(n-3)+3] = Y[n-3]; // dn-2
-					coeffs[4*(n-2)] = a; // an-1
-					coeffs[4*(n-2)+1] = 3 * a * h2 + coeffs[4*(n-3)+1]; // bn-1
-					coeffs[4*(n-2)+2] = 3 * a * std::pow(h2, 2) + 2 * coeffs[4*(n-3)+1] * h2 + coeffs[4*(n-3)+2]; // cn-1
-					coeffs[4*(n-2)+3] = Y[n-2]; // dn-1
-				}
+					for (SizeT i = 0, index = 0; i < n - 1; ++i) {
+						coeffs[index++] = A[i];
+						coeffs[index++] = B[i];
+						coeffs[index++] = C[i];
+						coeffs[index++] = Y[i];
+					}
+				},
+				[&](const typename Types::NotAKnot&) {
+					if (n <= 4) {
+						coeffs = util::spline::simple_spline<Number,Container>(X, Y, 3);
+						return;
+					}
 
-				for (SizeT iter = 0; iter <= n - 5; ++iter) {
-					const auto i = n - 5 - iter;
-					coeffs[4*i] = (coeffs[4*(i+1)+1] - coeffs[4*(i+1)+2]/dX[i] + dY[i]/pow(dX[i], 2)) / dX[i];
-					coeffs[4*i+1] = coeffs[4*(i+1)+1] - 3 * coeffs[4*i] * dX[i];
-					coeffs[4*i+2] = dY[i]/dX[i] - coeffs[4*i]*pow(dX[i], 2) - coeffs[4*i+1]*dX[i];
-					coeffs[4*i+3] = Y[i];
-				}
-			} else if (type == Type::SEMI_NOT_A_KNOT) {
-				return util::arrays::mean(compute_coeffs(X, Y, Type::NOT_A_KNOT_START), compute_coeffs(X, Y, Type::NOT_A_KNOT_END));
-			} else {
-				std::cerr << "Error in function " << __FUNCTION__
-						  << ": unknown type (" << static_cast<int>(type)
-						  << "). Returning an empty array..." << std::endl;
-				return {};
-			}
+					const Container<Number> dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
+
+					const auto big_denominator = dX[n-2] * (dX[n-3] + dX[n-2]) * (2*dX[n-3] + dX[n-2]);
+
+					Container<Number> B(n - 1);
+
+					Container<Number> diagonal(n - 3), right(n - 3);
+					diagonal[0] = ((dX[0] + dX[1]) * (dX[0] + 2 * dX[1])) / dX[1];
+					for (SizeT i = 1; i < n - 4; ++i) {
+						diagonal[i] = 2 * (dX[i] + dX[i+1]);
+					}
+					diagonal[n-4] = 2 * dX[n-4] + 3 * dX[n-3] * (1 - dX[n-3] / (2 * dX[n-3] + dX[n-2]));
+					for (SizeT i = 0; i < n - 4; ++i) {
+						right[i] = 3 * (dY[i+1] / dX[i+1] - dY[i] / dX[i]);
+					}
+					right[n-4] = 3 * (dY[n-3]/dX[n-3] - dY[n-4]/dX[n-4]) - (3*dX[n-3]*(dY[n-2]*dX[n-3] - dY[n-3]*dX[n-2])) / big_denominator;
+
+					diagonal[1] -= dX[1] / diagonal[0] * (dX[1] - (dX[0] * dX[0]) / dX[1]);
+					right[1] -= dX[1] / diagonal[0] * right[0];
+					for (SizeT i = 2; i < n - 3; ++i) {
+						const auto m = dX[i] / diagonal[i-1];
+						diagonal[i] -= m * dX[i];
+						right[i] -= m * right[i-1];
+					}
+
+					B[n-3] = right[n-4] / diagonal[n-4];
+					for (SizeT i = n - 4; i >= 2; --i) {
+						B[i] = (right[i-1] - dX[i] * B[i+1]) / diagonal[i-1];
+					}
+					B[1] = (right[0] - (dX[1] - (dX[0] * dX[0]) / dX[1]) * B[2]) / diagonal[0];
+
+					B[n-2] = (dX[n-2]*(B[n-3]*(dX[n-2]*dX[n-2] - dX[n-3]*dX[n-3]) - 3*dY[n-3]) + 3*dX[n-3]*dY[n-2]) / big_denominator;
+
+					Container<Number> A(n - 1);
+					for (SizeT i = 1; i < A.size() - 1; ++i) {
+						A[i] = (B[i+1] - B[i]) / (3*dX[i]);
+					}
+					A[0] = A[1];
+					A[n-2] = A[n-3];
+
+					B[0] = B[1] - 3 * A[0] * dX[0];
+
+					Container<Number> C(n - 1);
+					for (SizeT i = 0; i < C.size() - 1; ++i) {
+						C[i] = dY[i] / dX[i] - dX[i] * ((2*B[i] + B[i+1]) / 3);
+					}
+					C[n-2] = dY[n-2] / dX[n-2] - A[n-2] * dX[n-2] * dX[n-2] - B[n-2] * dX[n-2];
+
+					for (SizeT i = 0, index = 0; i < n - 1; ++i) {
+						coeffs[index++] = A[i];
+						coeffs[index++] = B[i];
+						coeffs[index++] = C[i];
+						coeffs[index++] = Y[i];
+					}
+				},
+				[&](const typename Types::Periodic&) {
+					if (n <= 2) {
+						coeffs = util::spline::simple_spline<Number,Container>(X, Y, 3);
+						return;
+					}
+
+					const Container<Number> dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
+
+					Container<Number> B(n);
+					if (n == 3) {
+						B[0] = 3 * (dY[0] / dX[0] - dY[1] / dX[1]) / (dX[0] + dX[1]);
+						B[1] = -B[0];
+						B[2] = B[0];
+					} else {
+						Container<Number> diag(n - 1), right(n - 1);
+						for (SizeT i = 0; i < n - 2; ++i) {
+							diag[i] = 2 * (dX[i] + dX[i+1]);
+							right[i] = 3 * (dY[i+1] / dX[i+1] - dY[i] / dX[i]);
+						}
+						diag[n-2] = 2 * (dX[n-2] + dX[0]);
+						right[n-2] = 3 * (dY[0]/dX[0] - dY[n-2]/dX[n-2]);
+
+						Container<Number> last_row(n - 2), last_col(n - 2);
+						last_row[0] = last_col[0] = dX[0];
+						for (SizeT i = 1; i < n - 3; ++i) {
+							last_row[i] = last_col[i] = 0;
+						}
+						last_row[n-3] = last_col[n-3] = dX[n-2];
+
+						for (SizeT i = 0; i < n - 3; ++i) {
+							const auto m1 = dX[i+1] / diag[i];
+							diag[i+1] -= m1 * dX[i+1];
+							last_col[i+1] -= m1 * last_col[i];
+							right[i+1] -= m1 * right[i];
+							const auto m2 = last_row[i] / diag[i];
+							last_row[i+1] -= m2 * dX[i+1];
+							diag[n-2] -= m2 * last_col[i];
+							right[n-2] -= m2 * right[i];
+						}
+						diag[n-2] -= last_row[n-3] / diag[n-3] * last_col[n-3];
+						right[n-2] -= last_row[n-3] / diag[n-3] * right[n-3];
+
+						B[n-1] = right[n-2] / diag[n-2];
+						B[n-2] = (right[n-3] - last_col[n-3] * B[n-1]) / diag[n-3];
+						for (SizeT i = n - 3; i >= 1; --i) {
+							B[i] = (right[i-1] - dX[i]*B[i+1] - last_col[i-1]*B[n-1]) / diag[i-1];
+						}
+						B[0] = B[n-1];
+					}
+
+					Container<Number> A(n - 1);
+					for (SizeT i = 0; i < A.size(); ++i) {
+						A[i] = (B[i+1] - B[i]) / (3*dX[i]);
+					}
+
+					Container<Number> C(n - 1);
+					for (SizeT i = 0; i < C.size(); ++i) {
+						C[i] = dY[i] / dX[i] - dX[i] * ((2*B[i] + B[i+1]) / 3);
+					}
+
+					for (SizeT i = 0, index = 0; i < n - 1; ++i) {
+						coeffs[index++] = A[i];
+						coeffs[index++] = B[i];
+						coeffs[index++] = C[i];
+						coeffs[index++] = Y[i];
+					}
+				},
+				[&](const typename Types::NotAKnotStart&) {
+					if (n <= 4) {
+						coeffs = util::spline::simple_spline<Number,Container>(X, Y, 3);
+						return;
+					}
+
+					const Container<Number> dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
+
+					{ // first four points
+						const auto h1 = dX[0], h2 = dX[1];
+						const auto h12 = X[2]-X[0], h13 = X[3]-X[0];
+						const auto d1 = Y[1]-Y[0], d12 = Y[2]-Y[0], d13 = Y[3]-Y[0];
+
+						const auto abc = util::linalg::linsolve(
+							{{std::pow(h1, 3), std::pow(h1, 2), h1},
+								{std::pow(h12, 3), std::pow(h12, 2), h12},
+								{std::pow(h13, 3), std::pow(h13, 2), h13}},
+							{d1, d12, d13});
+						if (abc.empty()) {
+							std::cerr << "Error in function " << FUNCTION << ": Could not compute. Returning an empty array..." << std::endl;
+							coeffs = {};
+							return;
+						}
+
+						const auto a = abc[0], b = abc[1], c = abc[2];
+
+						coeffs[0] = a; // a1
+						coeffs[1] = b; // b1
+						coeffs[2] = c; // c1
+						coeffs[3] = Y[0]; // d1
+						coeffs[4] = a; // a2
+						coeffs[5] = 3 * a * h1 + b; // b2
+						coeffs[6] = 3 * a * std::pow(h1, 2) + 2 * b * h1 + c; // c2
+						coeffs[7] = Y[1]; // d2
+						coeffs[8] = a; // a3
+						coeffs[9] = 3 * a * h2 + coeffs[5]; // b3
+						coeffs[10] = 3 * a * std::pow(h2, 2) + 2 * coeffs[5] * h2 + coeffs[6]; // c3
+						coeffs[11] = Y[2]; // d3
+					}
+
+					for (SizeT i = 3; i < n - 1; ++i) {
+						coeffs[4*i+3] = Y[i];
+						coeffs[4*i+2] = 3 * coeffs[4*(i-1)] * pow(dX[i-1], 2) + 2 * coeffs[4*(i-1)+1] * dX[i-1] + coeffs[4*(i-1)+2];
+						coeffs[4*i+1] = 3 * coeffs[4*(i-1)] * dX[i-1] + coeffs[4*(i-1)+1];
+						coeffs[4*i] = (dY[i]/dX[i] - coeffs[4*i+1] * dX[i] - coeffs[4*i+2]) / pow(dX[i], 2);
+					}
+				},
+				[&](const typename Types::NotAKnotEnd&) {
+					if (n <= 4) {
+						coeffs = util::spline::simple_spline<Number,Container>(X, Y, 3);
+						return;
+					}
+
+					const Container<Number> dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
+
+					{ // last four points
+						const auto h1 = dX[n-4], h2 = dX[n-3];
+						const auto h12 = X[n-2]-X[n-4], h13 = X[n-1]-X[n-4];
+						const auto d1 = dY[n-4], d12 = Y[n-2] - Y[n-4], d13 = Y[n-1] - Y[n-4];
+
+						const auto abc = util::linalg::linsolve(
+							{{std::pow(h1, 3), std::pow(h1, 2), h1},
+								{std::pow(h12, 3), std::pow(h12, 2), h12},
+								{std::pow(h13, 3), std::pow(h13, 2), h13}},
+							{d1, d12, d13});
+						if (abc.empty()) {
+							std::cerr << "Error in function " << FUNCTION << ": Could not compute. Returning an empty array..." << std::endl;
+							coeffs = {};
+							return;
+						}
+
+						const auto a = abc[0], b = abc[1], c = abc[2];
+
+						coeffs[4*(n-4)] = a; // an-3
+						coeffs[4*(n-4)+1] = b; // bn-3
+						coeffs[4*(n-4)+2] = c; // cn-3
+						coeffs[4*(n-4)+3] = Y[n-4]; // dn-3
+						coeffs[4*(n-3)] = a; // an-2
+						coeffs[4*(n-3)+1] = 3 * a * h1 + b; // bn-2
+						coeffs[4*(n-3)+2] = 3 * a * std::pow(h1, 2) + 2 * b * h1 + c; // cn-2
+						coeffs[4*(n-3)+3] = Y[n-3]; // dn-2
+						coeffs[4*(n-2)] = a; // an-1
+						coeffs[4*(n-2)+1] = 3 * a * h2 + coeffs[4*(n-3)+1]; // bn-1
+						coeffs[4*(n-2)+2] = 3 * a * std::pow(h2, 2) + 2 * coeffs[4*(n-3)+1] * h2 + coeffs[4*(n-3)+2]; // cn-1
+						coeffs[4*(n-2)+3] = Y[n-2]; // dn-1
+					}
+
+					for (SizeT iter = 0; iter <= n - 5; ++iter) {
+						const auto i = n - 5 - iter;
+						coeffs[4*i] = (coeffs[4*(i+1)+1] - coeffs[4*(i+1)+2]/dX[i] + dY[i]/pow(dX[i], 2)) / dX[i];
+						coeffs[4*i+1] = coeffs[4*(i+1)+1] - 3 * coeffs[4*i] * dX[i];
+						coeffs[4*i+2] = dY[i]/dX[i] - coeffs[4*i]*pow(dX[i], 2) - coeffs[4*i+1]*dX[i];
+						coeffs[4*i+3] = Y[i];
+					}
+				},
+				[&](const typename Types::SemiNotAKnot&) {
+					coeffs = util::arrays::mean(compute_coeffs(X, Y, typename Types::NotAKnotStart{}), compute_coeffs(X, Y, typename Types::NotAKnotEnd{}));
+				},
+			}, type);
 
 			return coeffs;
 		}
@@ -339,7 +354,7 @@ namespace alfi::spline {
 		CubicSpline() = default;
 
 		template <typename ContainerXType>
-		CubicSpline(ContainerXType&& X, const auto& Y, Type type = Type::Default) {
+		CubicSpline(ContainerXType&& X, const auto& Y, Type type = typename Types::Default{}) {
 			construct(std::forward<ContainerXType>(X), Y, type);
 		}
 
@@ -350,7 +365,7 @@ namespace alfi::spline {
 		CubicSpline& operator=(CubicSpline&& other) noexcept = default;
 
 		template <typename ContainerXType>
-		void construct(ContainerXType&& X, const auto& Y, Type type = Type::Default) {
+		void construct(ContainerXType&& X, const auto& Y, Type type = typename Types::Default{}) {
 			if (X.size() != Y.size()) {
 				std::cerr << "Error in function " << __FUNCTION__
 						  << ": Vectors X (of size " << X.size()
@@ -372,15 +387,15 @@ namespace alfi::spline {
 		Number eval(Number x) const {
 			return eval(x, std::distance(_X.begin(), util::misc::first_leq_or_begin(_X.begin(), _X.end(), x)));
 		}
-		Number eval(Number x, SizeT segment_index) const {
+		Number eval(Number x, SizeT segment) const {
 			if (_coeffs.empty()) {
 				return NAN;
 			} else if (_coeffs.size() == 1) {
 				return _coeffs[0];
 			}
-			segment_index = std::max(std::min(segment_index, static_cast<SizeT>(_X.size() - 2)), static_cast<SizeT>(0));
-			x = x - _X[segment_index];
-			return ((_coeffs[4*segment_index] * x + _coeffs[4*segment_index+1]) * x + _coeffs[4*segment_index+2]) * x + _coeffs[4*segment_index+3];
+			segment = std::clamp(segment, static_cast<SizeT>(0), static_cast<SizeT>(_X.size() - 2));
+			x = x - _X[segment];
+			return ((_coeffs[4*segment] * x + _coeffs[4*segment+1]) * x + _coeffs[4*segment+2]) * x + _coeffs[4*segment+3];
 		}
 
 		Container<Number> eval(const Container<Number>& xx, bool sorted = true) const {
@@ -430,7 +445,7 @@ namespace alfi::spline {
 		}
 
 	private:
-		Type _type = Type::Default;
+		Type _type = typename Types::Default{};
 		Container<Number> _X = {};
 		Container<Number> _coeffs = {};
 	};

--- a/ALFI/ALFI/spline/linear.h
+++ b/ALFI/ALFI/spline/linear.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <iostream>
 #include <cmath>
 
@@ -78,15 +79,15 @@ namespace alfi::spline {
 		Number eval(Number x) const {
 			return eval(x, std::distance(_X.begin(), util::misc::first_leq_or_begin(_X.begin(), _X.end(), x)));
 		}
-		Number eval(Number x, SizeT segment_index) const {
+		Number eval(Number x, SizeT segment) const {
 			if (_coeffs.empty()) {
 				return NAN;
 			} else if (_coeffs.size() == 1) {
 				return _coeffs[0];
 			}
-			segment_index = std::max(std::min(segment_index, static_cast<SizeT>(_X.size() - 2)), static_cast<SizeT>(0));
-			x = x - _X[segment_index];
-			return _coeffs[2*segment_index] * x + _coeffs[2*segment_index+1];
+			segment = std::clamp(segment, static_cast<SizeT>(0), static_cast<SizeT>(_X.size() - 2));
+			x = x - _X[segment];
+			return _coeffs[2*segment] * x + _coeffs[2*segment+1];
 		}
 
 		Container<Number> eval(const Container<Number>& xx, bool sorted = true) const {

--- a/ALFI/ALFI/spline/quadratic.h
+++ b/ALFI/ALFI/spline/quadratic.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <algorithm>
 #include <iostream>
 #include <cmath>
+#include <variant>
 
 #include "../config.h"
 #include "../util/arrays.h"
@@ -12,44 +14,51 @@ namespace alfi::spline {
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
 	class QuadraticSpline {
 	public:
-		enum class Type {
-			/**
-			 * The second derivative at the first point is equal to zero.
-			 */
-			NATURAL_START,
-			/**
-			 * The second derivative at the last point is equal to zero.
-			 */
-			NATURAL_END,
-			/**
-			 * The arithmetic mean_array between NATURAL_START and NATURAL_END.
-			 */
-			SEMI_NATURAL,
+		struct Types final {
 			/**
 			 * A parabola is constructed through the first three points. Then each subsequent segment is built sequentially.\n
 			 * This is equivalent to the condition of continuity of the second derivative at the second point.\n
 			 * In this way, the second point "ceases to be a knot point".
 			 */
-			NOT_A_KNOT_START,
+			struct NotAKnotStart final {};
 			/**
 			 * A parabola is constructed through the last three points. Then each previous segment is built sequentially.\n
 			 * This is equivalent to the condition of continuity of the second derivative at the second-to-last point.\n
 			 * In this way, the second-to-last point "ceases to be a knot point".
 			 */
-			NOT_A_KNOT_END,
+			struct NotAKnotEnd final {};
 			/**
-			 * The arithmetic mean_array between NOT_A_KNOT_START and NOT_A_KNOT_END.
+			 * The arithmetic mean_array between NotAKnotStart and NotAKnotEnd.
 			 */
-			SEMI_NOT_A_KNOT,
+			struct SemiNotAKnot final {};
 			/**
-			 * The arithmetic mean_array between SEMI_NATURAL and SEMI_NOT_A_KNOT.
+			 * The second derivative at the first point is equal to zero.
 			 */
-			SEMI_SEMI,
-
-			Default = NATURAL_START,
+			struct NaturalStart final {};
+			/**
+			 * The second derivative at the last point is equal to zero.
+			 */
+			struct NaturalEnd final {};
+			/**
+			 * The arithmetic mean_array between NaturalStart and NaturalEnd.
+			 */
+			struct SemiNatural final {};
+			/**
+			 * The arithmetic mean_array between SemiNotAKnot and SemiNatural.
+			 */
+			struct SemiSemi final {};
+			using Default = SemiNotAKnot;
 		};
 
-		static Container<Number> compute_coeffs(const auto& X, const auto& Y, Type type = Type::Default) {
+		using Type = std::variant<typename Types::NotAKnotStart,
+								  typename Types::NotAKnotEnd,
+								  typename Types::SemiNotAKnot,
+								  typename Types::NaturalStart,
+								  typename Types::NaturalEnd,
+								  typename Types::SemiNatural,
+								  typename Types::SemiSemi>;
+
+		static Container<Number> compute_coeffs(const auto& X, const auto& Y, Type type = typename Types::Default{}) {
 			if (X.size() != Y.size()) {
 				std::cerr << "Error in function " << __FUNCTION__
 						  << ": Vectors X (of size " << X.size()
@@ -66,88 +75,95 @@ namespace alfi::spline {
 
 			Container<Number> coeffs(3 * (n - 1));
 
-			if (type == Type::NATURAL_START) {
-				if (n <= 2) {
-					return util::spline::simple_spline<Number,Container>(X, Y, 2);
-				}
-				coeffs[0] = 0; // a1 = 0
-				coeffs[1] = (Y[1] - Y[0]) / (X[1] - X[0]); // b1
-				coeffs[2] = Y[0]; // c1
-				for (SizeT i = 1; i < n - 1; ++i) {
-					coeffs[3*i+1] = 2 * (Y[i] - Y[i-1]) / (X[i] - X[i-1]) - coeffs[3*(i-1)+1];
-					coeffs[3*i] = ((Y[i+1] - Y[i]) / (X[i+1] - X[i]) - coeffs[3*i+1]) / (X[i+1] - X[i]);
-					// another way: coeffs[3*i] = (coeffs[3*(i+1)+1] - coeffs[3*i+1]) / 2 / (X[i+1] - X[i]);
-					coeffs[3*i+2] = Y[i];
-				}
-			} else if (type == Type::NATURAL_END) {
-				if (n <= 2) {
-					return util::spline::simple_spline<Number,Container>(X, Y, 2);
-				}
-				coeffs[3*(n-2)] = 0; // an-1 = 0
-				coeffs[3*(n-2)+1] = (Y[n-1] - Y[n-2]) / (X[n-1] - X[n-2]); // bn-1
-				coeffs[3*(n-2)+2] = Y[n-2]; // cn-1
-				for (SizeT iter = 0; iter <= n - 3; ++iter) {
-					const SizeT i = n - 3 - iter;
-					coeffs[3*i+1] = 2 * (Y[i+1] - Y[i]) / (X[i+1] - X[i]) - coeffs[3*(i+1)+1];
-					// another way: coeffs[3*i] = ((Y[i+1] - Y[i]) / (X[i+1] - X[i]) - coeffs[3*i+1]) / (X[i+1] - X[i]);
-					coeffs[3*i] = (coeffs[3*(i+1)+1] - coeffs[3*i+1]) / 2 / (X[i+1] - X[i]);
-					coeffs[3*i+2] = Y[i];
-				}
-			} else if (type == Type::SEMI_NATURAL) {
-				return util::arrays::mean(compute_coeffs(X, Y, Type::NATURAL_START), compute_coeffs(X, Y, Type::NATURAL_END));
-			} else if (type == Type::NOT_A_KNOT_START) {
-				if (n <= 3) {
-					return util::spline::simple_spline<Number,Container>(X, Y, 2);
-				}
-				{ // first three points
-					const Number h1 = X[1] - X[0], h2 = X[2] - X[1];
-					const Number d1 = (Y[1] - Y[0]) / h1, d2 = (Y[2] - Y[1]) / h2;
-					coeffs[0] = (d2 - d1) / (h1 + h2); // a1
-					coeffs[1] = d1 - h1 * coeffs[0];  // b1
-					coeffs[2] = Y[0];                  // c1
-					coeffs[3] = coeffs[0];            // a2
-					coeffs[4] = d1 + h1 * coeffs[0];  // b2
-					coeffs[5] = Y[1];                  // c2
-				}
-				for (SizeT i = 2; i < n - 1; ++i) {
-					const Number hi = X[i+1] - X[i], hi_1 = X[i] - X[i-1];
-					const Number d = 2 * coeffs[3*(i-1)] * hi_1 + coeffs[3*(i-1)+1];
-					coeffs[3*i] = ((Y[i+1] - Y[i])/hi - d) / hi;
-					coeffs[3*i+1] = d;
-					coeffs[3*i+2] = Y[i];
-				}
-			} else if (type == Type::NOT_A_KNOT_END) {
-				if (n <= 3) {
-					return util::spline::simple_spline<Number,Container>(X, Y, 2);
-				}
-				{ // last three points
-					const Number hn_2 = X[n-2] - X[n-3], hn_1 = X[n-1] - X[n-2];
-					const Number dn_2 = (Y[n-2] - Y[n-3]) / hn_2, dn_1 = (Y[n-1] - Y[n-2]) / hn_1;
-					coeffs[3*(n-3)] = (dn_1 - dn_2) / (hn_2 + hn_1);    // an-2
-					coeffs[3*(n-3)+1] = dn_2 - hn_2 * coeffs[3*(n-3)]; // bn-2
-					coeffs[3*(n-3)+2] = Y[n-3];                         // cn-2
-					coeffs[3*(n-2)] = coeffs[3*(n-3)];                 // an-1
-					coeffs[3*(n-2)+1] = dn_2 + hn_2 * coeffs[3*(n-3)]; // bn-1
-					coeffs[3*(n-2)+2] = Y[n-2];                         // cn-1
-				}
-				for (SizeT iter = 0; iter <= n - 4; ++iter) {
-					const SizeT i = n - 4 - iter;
-					const Number hi = X[i+1] - X[i];
-					coeffs[3*i] = (coeffs[3*(i+1)+1] - (Y[i+1] - Y[i])/hi) / hi;
-					coeffs[3*i+1] = coeffs[3*(i+1)+1] - 2*coeffs[3*i]*hi;
-					// another way: coeffs[3*i+1] = (Y[i+1] - Y[i])/hi - coeffs[3*i]*hi;
-					coeffs[3*i+2] = Y[i];
-				}
-			} else if (type == Type::SEMI_NOT_A_KNOT) {
-				return util::arrays::mean(compute_coeffs(X, Y, Type::NOT_A_KNOT_START), compute_coeffs(X, Y, Type::NOT_A_KNOT_END));
-			} else if (type == Type::SEMI_SEMI) {
-				return util::arrays::mean(compute_coeffs(X, Y, Type::SEMI_NATURAL), compute_coeffs(X, Y, Type::SEMI_NOT_A_KNOT));
-			} else {
-				std::cerr << "Error in function " << __FUNCTION__
-						  << ": unknown type (" << static_cast<int>(type)
-						  << "). Returning an empty array..." << std::endl;
-				return {};
-			}
+			std::visit(util::misc::overload{
+				[&](const typename Types::NotAKnotStart&) {
+					if (n <= 3) {
+						coeffs = util::spline::simple_spline<Number,Container>(X, Y, 2);
+						return;
+					}
+					{ // first three points
+						const Number h1 = X[1] - X[0], h2 = X[2] - X[1];
+						const Number d1 = (Y[1] - Y[0]) / h1, d2 = (Y[2] - Y[1]) / h2;
+						coeffs[0] = (d2 - d1) / (h1 + h2); // a1
+						coeffs[1] = d1 - h1 * coeffs[0]; // b1
+						coeffs[2] = Y[0]; // c1
+						coeffs[3] = coeffs[0]; // a2
+						coeffs[4] = d1 + h1 * coeffs[0]; // b2
+						coeffs[5] = Y[1]; // c2
+					}
+					for (SizeT i = 2; i < n - 1; ++i) {
+						const Number hi = X[i+1] - X[i], hi_1 = X[i] - X[i-1];
+						const Number d = 2 * coeffs[3*(i-1)] * hi_1 + coeffs[3*(i-1)+1];
+						coeffs[3*i] = ((Y[i+1] - Y[i])/hi - d) / hi;
+						coeffs[3*i+1] = d;
+						coeffs[3*i+2] = Y[i];
+					}
+				},
+				[&](const typename Types::NotAKnotEnd&) {
+					if (n <= 3) {
+						coeffs = util::spline::simple_spline<Number,Container>(X, Y, 2);
+						return;
+					}
+					{ // last three points
+						const Number hn_2 = X[n-2] - X[n-3], hn_1 = X[n-1] - X[n-2];
+						const Number dn_2 = (Y[n-2] - Y[n-3]) / hn_2, dn_1 = (Y[n-1] - Y[n-2]) / hn_1;
+						coeffs[3*(n-3)] = (dn_1 - dn_2) / (hn_2 + hn_1); // an-2
+						coeffs[3*(n-3)+1] = dn_2 - hn_2 * coeffs[3*(n-3)]; // bn-2
+						coeffs[3*(n-3)+2] = Y[n-3]; // cn-2
+						coeffs[3*(n-2)] = coeffs[3*(n-3)]; // an-1
+						coeffs[3*(n-2)+1] = dn_2 + hn_2 * coeffs[3*(n-3)]; // bn-1
+						coeffs[3*(n-2)+2] = Y[n-2]; // cn-1
+					}
+					for (SizeT iter = 0; iter <= n - 4; ++iter) {
+						const SizeT i = n - 4 - iter;
+						const Number hi = X[i+1] - X[i];
+						coeffs[3*i] = (coeffs[3*(i+1)+1] - (Y[i+1] - Y[i])/hi) / hi;
+						coeffs[3*i+1] = coeffs[3*(i+1)+1] - 2*coeffs[3*i]*hi;
+						// another way: coeffs[3*i+1] = (Y[i+1] - Y[i])/hi - coeffs[3*i]*hi;
+						coeffs[3*i+2] = Y[i];
+					}
+				},
+				[&](const typename Types::SemiNotAKnot&) {
+					coeffs = util::arrays::mean(compute_coeffs(X, Y, typename Types::NotAKnotStart{}), compute_coeffs(X, Y, typename Types::NotAKnotEnd{}));
+				},
+				[&](const typename Types::NaturalStart&) {
+					if (n <= 2) {
+						coeffs = util::spline::simple_spline<Number,Container>(X, Y, 2);
+						return;
+					}
+					coeffs[0] = 0; // a1 = 0
+					coeffs[1] = (Y[1] - Y[0]) / (X[1] - X[0]); // b1
+					coeffs[2] = Y[0]; // c1
+					for (SizeT i = 1; i < n - 1; ++i) {
+						coeffs[3*i+1] = 2 * (Y[i] - Y[i-1]) / (X[i] - X[i-1]) - coeffs[3*(i-1)+1];
+						coeffs[3*i] = ((Y[i+1] - Y[i]) / (X[i+1] - X[i]) - coeffs[3*i+1]) / (X[i+1] - X[i]);
+						// another way: coeffs[3*i] = (coeffs[3*(i+1)+1] - coeffs[3*i+1]) / 2 / (X[i+1] - X[i]);
+						coeffs[3*i+2] = Y[i];
+					}
+				},
+				[&](const typename Types::NaturalEnd&) {
+					if (n <= 2) {
+						coeffs = util::spline::simple_spline<Number,Container>(X, Y, 2);
+						return;
+					}
+					coeffs[3*(n-2)] = 0; // an-1 = 0
+					coeffs[3*(n-2)+1] = (Y[n-1] - Y[n-2]) / (X[n-1] - X[n-2]); // bn-1
+					coeffs[3*(n-2)+2] = Y[n-2]; // cn-1
+					for (SizeT iter = 0; iter <= n - 3; ++iter) {
+						const SizeT i = n - 3 - iter;
+						coeffs[3*i+1] = 2 * (Y[i+1] - Y[i]) / (X[i+1] - X[i]) - coeffs[3*(i+1)+1];
+						// another way: coeffs[3*i] = ((Y[i+1] - Y[i]) / (X[i+1] - X[i]) - coeffs[3*i+1]) / (X[i+1] - X[i]);
+						coeffs[3*i] = (coeffs[3*(i+1)+1] - coeffs[3*i+1]) / 2 / (X[i+1] - X[i]);
+						coeffs[3*i+2] = Y[i];
+					}
+				},
+				[&](const typename Types::SemiNatural&) {
+					coeffs = util::arrays::mean(compute_coeffs(X, Y, typename Types::NaturalStart{}), compute_coeffs(X, Y, typename Types::NaturalEnd{}));
+				},
+				[&](const typename Types::SemiSemi&) {
+					coeffs = util::arrays::mean(compute_coeffs(X, Y, typename Types::SemiNotAKnot{}), compute_coeffs(X, Y, typename Types::SemiNatural{}));
+				},
+			}, type);
 
 			return coeffs;
 		}
@@ -155,7 +171,7 @@ namespace alfi::spline {
 		QuadraticSpline() = default;
 
 		template <typename ContainerXType>
-		QuadraticSpline(ContainerXType&& X, const auto& Y, Type type = Type::Default) {
+		QuadraticSpline(ContainerXType&& X, const auto& Y, Type type = typename Types::Default{}) {
 			construct(std::forward<ContainerXType>(X), Y, type);
 		}
 
@@ -166,7 +182,7 @@ namespace alfi::spline {
 		QuadraticSpline& operator=(QuadraticSpline&& other) noexcept = default;
 
 		template <typename ContainerXType>
-		void construct(ContainerXType&& X, const auto& Y, Type type = Type::Default) {
+		void construct(ContainerXType&& X, const auto& Y, Type type = typename Types::Default{}) {
 			if (X.size() != Y.size()) {
 				std::cerr << "Error in function " << __FUNCTION__
 						  << ": Vectors X (of size " << X.size()
@@ -188,15 +204,15 @@ namespace alfi::spline {
 		Number eval(Number x) const {
 			return eval(x, std::distance(_X.begin(), util::misc::first_leq_or_begin(_X.begin(), _X.end(), x)));
 		}
-		Number eval(Number x, SizeT segment_index) const {
+		Number eval(Number x, SizeT segment) const {
 			if (_coeffs.empty()) {
 				return NAN;
 			} else if (_coeffs.size() == 1) {
 				return _coeffs[0];
 			}
-			segment_index = std::max(std::min(segment_index, static_cast<SizeT>(_X.size() - 2)), static_cast<SizeT>(0));
-			x = x - _X[segment_index];
-			return (_coeffs[3*segment_index] * x + _coeffs[3*segment_index+1]) * x + _coeffs[3*segment_index+2];
+			segment = std::clamp(segment, static_cast<SizeT>(0), static_cast<SizeT>(_X.size() - 2));
+			x = x - _X[segment];
+			return (_coeffs[3*segment] * x + _coeffs[3*segment+1]) * x + _coeffs[3*segment+2];
 		}
 
 		Container<Number> eval(const Container<Number>& xx, bool sorted = true) const {
@@ -246,7 +262,7 @@ namespace alfi::spline {
 		}
 
 	private:
-		Type _type = Type::Default;
+		Type _type = typename Types::Default{};
 		Container<Number> _X = {};
 		Container<Number> _coeffs = {};
 	};

--- a/ALFI/ALFI/util/misc.h
+++ b/ALFI/ALFI/util/misc.h
@@ -1,18 +1,27 @@
 #pragma once
 
-#include <functional>
+#include <algorithm>
+#include <utility>
 
 namespace alfi::util::misc {
+	template <typename Function>
 	class SimpleScopeGuard {
 	public:
 		// ReSharper disable once CppNonExplicitConvertingConstructor
-		SimpleScopeGuard(std::function<void()> on_exit) : _on_exit(std::move(on_exit)) {} // NOLINT(*-explicit-constructor)
+		SimpleScopeGuard(Function on_exit) : _on_exit(std::move(on_exit)) {} // NOLINT(*-explicit-constructor)
 		~SimpleScopeGuard() noexcept { _on_exit(); }
 		SimpleScopeGuard(const SimpleScopeGuard&) = delete;
 		SimpleScopeGuard& operator=(const SimpleScopeGuard&) = delete;
 	private:
-		std::function<void()> _on_exit;
+		Function _on_exit;
 	};
+
+	template <typename... Ts>
+	struct overload : Ts... {
+		using Ts::operator()...;
+	};
+	template <typename... Ts>
+	overload(Ts...) -> overload<Ts...>;
 
 	template <typename Iterator, typename T>
 	Iterator first_leq_or_begin(Iterator begin, Iterator end, const T& value) {

--- a/tests/spline/test_step.cpp
+++ b/tests/spline/test_step.cpp
@@ -5,41 +5,63 @@
 TEST(StepSplineTest, General) {
 	const std::vector<double> X = {0, 1, 2, 3};
 	const std::vector<double> Y = {5, 2, 10, 4};
-	const auto left_spline = alfi::spline::StepSpline(X, Y, alfi::spline::StepSpline<>::Type::LEFT);
-	const auto right_spline = alfi::spline::StepSpline(X, Y, alfi::spline::StepSpline<>::Type::RIGHT);
-	const auto middle_spline = alfi::spline::StepSpline(X, Y, alfi::spline::StepSpline<>::Type::MIDDLE);
+	const auto left_spline = alfi::spline::StepSpline(X, Y, alfi::spline::StepSpline<>::Types::Left{});
+	const auto middle_spline = alfi::spline::StepSpline(X, Y, alfi::spline::StepSpline<>::Types::Middle{});
+	const auto right_spline = alfi::spline::StepSpline(X, Y, alfi::spline::StepSpline<>::Types::Right{});
+	const auto fraction_spline = alfi::spline::StepSpline(X, Y, alfi::spline::StepSpline<>::Types::Fraction{0.25});
+	const auto proportion_spline = alfi::spline::StepSpline(X, Y, alfi::spline::StepSpline<>::Types::Proportion{3, 7});
 	const auto epsilon = 0.0001;
 	for (size_t i = 0; i < X.size() - 1; ++i) {
-		// LEFT exact points
+		// Left exact points
 		EXPECT_EQ(left_spline(X[i]), Y[i]);
 		EXPECT_EQ(left_spline(X[i+1]), Y[i+1]);
-		// LEFT between points
+		// Left between points
 		EXPECT_EQ(left_spline(X[i] + epsilon), Y[i]);
 		EXPECT_EQ(left_spline((X[i]+X[i+1])/2), Y[i]);
 		EXPECT_EQ(left_spline(X[i+1] - epsilon), Y[i]);
 
-		// RIGHT exact points
+		// Middle exact points
+		EXPECT_EQ(middle_spline(X[i]), Y[i]);
+		EXPECT_EQ(middle_spline(X[i+1]), Y[i+1]);
+		// Middle between points
+		EXPECT_EQ(middle_spline(X[i] + epsilon), (Y[i]+Y[i+1])/2);
+		EXPECT_EQ(middle_spline((X[i]+X[i+1])/2), (Y[i]+Y[i+1])/2);
+		EXPECT_EQ(middle_spline(X[i+1] - epsilon), (Y[i]+Y[i+1])/2);
+
+		// Right exact points
 		EXPECT_EQ(right_spline(X[i]), Y[i]);
 		EXPECT_EQ(right_spline(X[i+1]), Y[i+1]);
-		// RIGHT between points
+		// Right between points
 		EXPECT_EQ(right_spline(X[i] + epsilon), Y[i+1]);
 		EXPECT_EQ(right_spline((X[i]+X[i+1])/2), Y[i+1]);
 		EXPECT_EQ(right_spline(X[i+1] - epsilon), Y[i+1]);
 
-		// MIDDLE exact points
-		EXPECT_EQ(middle_spline(X[i]), Y[i]);
-		EXPECT_EQ(middle_spline(X[i+1]), Y[i+1]);
-		// MIDDLE between points
-		EXPECT_EQ(middle_spline(X[i] + epsilon), (Y[i]+Y[i+1])/2);
-		EXPECT_EQ(middle_spline((X[i]+X[i+1])/2), (Y[i]+Y[i+1])/2);
-		EXPECT_EQ(middle_spline(X[i+1] - epsilon), (Y[i]+Y[i+1])/2);
+		// Fraction exact points
+		EXPECT_EQ(fraction_spline(X[i]), Y[i]);
+		EXPECT_EQ(fraction_spline(X[i+1]), Y[i+1]);
+		// Fraction between points
+		EXPECT_EQ(fraction_spline(X[i] + epsilon), Y[i] + 0.25*(Y[i+1] - Y[i]));
+		EXPECT_EQ(fraction_spline((X[i]+X[i+1])/2), Y[i] + 0.25*(Y[i+1] - Y[i]));
+		EXPECT_EQ(fraction_spline(X[i+1] - epsilon), Y[i] + 0.25*(Y[i+1] - Y[i]));
+
+		// Proportion exact points
+		EXPECT_EQ(proportion_spline(X[i]), Y[i]);
+		EXPECT_EQ(proportion_spline(X[i+1]), Y[i+1]);
+		// Proportion between points
+		EXPECT_EQ(proportion_spline(X[i] + epsilon), Y[i] + 0.3*(Y[i+1] - Y[i]));
+		EXPECT_EQ(proportion_spline((X[i]+X[i+1])/2), Y[i] + 0.3*(Y[i+1] - Y[i]));
+		EXPECT_EQ(proportion_spline(X[i+1] - epsilon), Y[i] + 0.3*(Y[i+1] - Y[i]));
 	}
 	EXPECT_EQ(left_spline(X.front() - 1), Y.front());
 	EXPECT_EQ(left_spline(X.back() + 1), Y.back());
-	EXPECT_EQ(right_spline(X.front() - 1), Y.front());
-	EXPECT_EQ(right_spline(X.back() + 1), Y.back());
 	EXPECT_EQ(middle_spline(X.front() - 1), Y.front());
 	EXPECT_EQ(middle_spline(X.back() + 1), Y.back());
+	EXPECT_EQ(right_spline(X.front() - 1), Y.front());
+	EXPECT_EQ(right_spline(X.back() + 1), Y.back());
+	EXPECT_EQ(fraction_spline(X.front() - 1), Y.front());
+	EXPECT_EQ(fraction_spline(X.back() + 1), Y.back());
+	EXPECT_EQ(proportion_spline(X.front() - 1), Y.front());
+	EXPECT_EQ(proportion_spline(X.back() + 1), Y.back());
 }
 
 TEST(StepSplineTest, Moving) {


### PR DESCRIPTION
### Types of changes
- Bug fix
- Feature
- Refactoring, reformatting, cleanup

Related: #6 #7 #8

### Description
- The type of spline types in `StepSpline`, `QuadraticSpline` and `CubicSpline` was changed from `enum class` to `std::variant` to support parameterized types.
- Changed the order of types and the default type for `QuadraticSpline`.
- Added two new types, `Fraction` and `Proportion`, to `StepSpline`.
- Updated tests for `StepSpline` accordingly.

> Also, a small bug fix for array out-of-bounds access in `StepSpline`.