### PR TITLE
Rebrand from `ALFI-library` to `ALFI-lib`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,5 @@
 	shallow = true
 [submodule "tests/test_data"]
 	path = tests/test_data
-	url = https://github.com/ALFI-library/test_data
+	url = https://github.com/ALFI-lib/test_data
 	shallow = true


### PR DESCRIPTION
### Types of changes
- Rebrand
- Configuration (project, submodule)

Related: #19

### Description
Rebrand from `ALFI-library` to `ALFI-lib`.