### PR TITLE
Renamed `sigmoid` to `logistic`

### DIFF
--- a/ALFI/ALFI/dist.h
+++ b/ALFI/ALFI/dist.h
@@ -15,8 +15,8 @@ namespace alfi::dist {
 		CHEBYSHEV_ELLIPSE_STRETCHED,
 		CIRCLE_PROJECTION,
 		ELLIPSE_PROJECTION,
-		SIGMOID,
-		SIGMOID_STRETCHED,
+		LOGISTIC,
+		LOGISTIC_STRETCHED,
 		ERF,
 		ERF_STRETCHED,
 	};
@@ -95,7 +95,7 @@ namespace alfi::dist {
 	}
 
 	/**
-		@brief Generates a distribution of \p n points on the interval `(a, b)` using the sigmoid function.
+		@brief Generates a distribution of \p n points on the interval `(a, b)` using the logistic function.
 
 		The following transform function \f(f\f):
 		\f[
@@ -118,20 +118,20 @@ namespace alfi::dist {
 		@return a container with \p n points distributed on the interval `(a, b)` according to the transform function
 	*/
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
-	Container<Number> sigmoid(SizeT n, Number a, Number b, Number steepness) {
+	Container<Number> logistic(SizeT n, Number a, Number b, Number steepness) {
 		if (n == 1)
 			return {(a+b)/2};
 		Container<Number> points(n);
 		for (SizeT i = 0; i < n; ++i) {
 			const Number x = 2 * static_cast<Number>(i) / (static_cast<Number>(n) - 1) - 1;
-			const Number sigmoidValue = 1 / (1 + exp(-steepness * x));
-			points[i] = a + (b - a) * sigmoidValue;
+			const Number logisticValue = 1 / (1 + std::exp(-steepness * x));
+			points[i] = a + (b - a) * logisticValue;
 		}
 		return points;
 	}
 
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
-	Container<Number> sigmoid_stretched(SizeT n, Number a, Number b, Number steepness) {
+	Container<Number> logistic_stretched(SizeT n, Number a, Number b, Number steepness) {
 		if (n == 0)
 			return {};
 		if (n == 1)
@@ -140,8 +140,8 @@ namespace alfi::dist {
 		const Number stretch_factor = 1 - 2 / (1 + std::exp(steepness));
 		for (SizeT i = 1; i < n - 1; ++i) {
 			const Number x = 2 * static_cast<double>(i) / (static_cast<Number>(n) - 1) - 1;
-			const Number sigmoid = 1 / (1 + std::exp(-steepness * x));
-			const Number stretched = (sigmoid - 1 / (1 + std::exp(steepness))) / stretch_factor;
+			const Number logisticValue = 1 / (1 + std::exp(-steepness * x));
+			const Number stretched = (logisticValue - 1 / (1 + std::exp(steepness))) / stretch_factor;
 			points[i] = a + (b - a) * stretched;
 		}
 		points[0] = a;
@@ -207,10 +207,10 @@ namespace alfi::dist {
 			return circle_proj(n, a, b);
 		case Type::ELLIPSE_PROJECTION:
 			return ellipse_proj(n, a, b, parameter);
-		case Type::SIGMOID:
-			return sigmoid(n, a, b, parameter);
-		case Type::SIGMOID_STRETCHED:
-			return sigmoid_stretched(n, a, b, parameter);
+		case Type::LOGISTIC:
+			return logistic(n, a, b, parameter);
+		case Type::LOGISTIC_STRETCHED:
+			return logistic_stretched(n, a, b, parameter);
 		case Type::ERF:
 			return erf(n, a, b, parameter);
 		case Type::ERF_STRETCHED:

--- a/examples/dist_QCustomPlot/dist_QCustomPlot.cpp
+++ b/examples/dist_QCustomPlot/dist_QCustomPlot.cpp
@@ -189,8 +189,8 @@ private:
 			{"Stretched Chebyshev Ellipse", alfi::dist::chebyshev_ellipse_stretched(n, a, b, B)},
 			{"Circle Projection", alfi::dist::circle_proj(n, a, b)},
 			{"Ellipse Projection", alfi::dist::ellipse_proj(n, a, b, B)},
-			{"Sigmoid", alfi::dist::sigmoid(n, a, b, steepness)},
-			{"Stretched Sigmoid", alfi::dist::sigmoid_stretched(n, a, b, steepness)},
+			{"Logistic", alfi::dist::logistic(n, a, b, steepness)},
+			{"Stretched Logistic", alfi::dist::logistic_stretched(n, a, b, steepness)},
 			{"Error function", alfi::dist::erf(n, a, b, steepness)},
 			{"Stretched Error function", alfi::dist::erf_stretched(n, a, b, steepness)},
 		};

--- a/examples/dist_gnuplot/dist_gnuplot.cpp
+++ b/examples/dist_gnuplot/dist_gnuplot.cpp
@@ -62,7 +62,7 @@ int main() {
 	const double b = 1;
 
 	const double ratio = 2;
-	const double sigmoid_steepness = 8;
+	const double logistic_steepness = 8;
 	const double erf_steepness = 3;
 
 	plot_data({
@@ -73,8 +73,8 @@ int main() {
 		{"Stretched Chebyshev Ellipse", alfi::dist::chebyshev_ellipse_stretched(n, a, b, ratio)},
 		{"Circle Projection", alfi::dist::circle_proj(n, a, b)},
 		{"Ellipse Projection", alfi::dist::ellipse_proj(n, a, b, ratio)},
-		{"Sigmoid", alfi::dist::sigmoid(n, a, b, sigmoid_steepness)},
-		{"Stretched Sigmoid", alfi::dist::sigmoid_stretched(n, a, b, sigmoid_steepness)},
+		{"Logistic", alfi::dist::logistic(n, a, b, logistic_steepness)},
+		{"Stretched Logistic", alfi::dist::logistic_stretched(n, a, b, logistic_steepness)},
 		{"Error function", alfi::dist::erf(n, a, b, erf_steepness)},
 		{"Stretched Error function", alfi::dist::erf_stretched(n, a, b, erf_steepness)},
 	});

--- a/examples/interpolation/interpolation.cpp
+++ b/examples/interpolation/interpolation.cpp
@@ -74,7 +74,7 @@ public:
 	PlotWindow() {
 		static const QStringList distribution_types {
 			"Uniform", "Chebyshev", "Chebyshev Stretched", "Chebyshev Ellipse", "Chebyshev Ellipse Stretched",
-			"Circle Projection", "Ellipse Projection", "Sigmoid", "Stretched Sigmoid",
+			"Circle Projection", "Ellipse Projection", "Logistic", "Stretched Logistic",
 			"Error Function", "Stretched Error Function"
 		};
 
@@ -268,8 +268,8 @@ private:
 			case alfi::dist::Type::CHEBYSHEV_ELLIPSE_STRETCHED: X = alfi::dist::chebyshev_ellipse_stretched(N, a, b, 2.0); break;
 			case alfi::dist::Type::CIRCLE_PROJECTION: X = alfi::dist::circle_proj(N, a, b); break;
 			case alfi::dist::Type::ELLIPSE_PROJECTION: X = alfi::dist::ellipse_proj(N, a, b, 2.0); break;
-			case alfi::dist::Type::SIGMOID: X = alfi::dist::sigmoid(N, a, b, 16.0); break;
-			case alfi::dist::Type::SIGMOID_STRETCHED: X = alfi::dist::sigmoid_stretched(N, a, b, 16.0); break;
+			case alfi::dist::Type::LOGISTIC: X = alfi::dist::logistic(N, a, b, 16.0); break;
+			case alfi::dist::Type::LOGISTIC_STRETCHED: X = alfi::dist::logistic_stretched(N, a, b, 16.0); break;
 			case alfi::dist::Type::ERF: X = alfi::dist::erf(N, a, b, 8.0); break;
 			case alfi::dist::Type::ERF_STRETCHED: X = alfi::dist::erf_stretched(N, a, b, 8.0); break;
 			default: return;

--- a/tests/dist/test_dist.cpp
+++ b/tests/dist/test_dist.cpp
@@ -62,12 +62,12 @@ TEST(DistributionsTest, EllipseProjection) {
 	test_distribution("ellipse_proj", alfi::dist::Type::ELLIPSE_PROJECTION, 1e-14);
 }
 
-TEST(DistributionsTest, Sigmoid) {
-	test_distribution("sigmoid", alfi::dist::Type::SIGMOID, 1e-13);
+TEST(DistributionsTest, Logistic) {
+	test_distribution("logistic", alfi::dist::Type::LOGISTIC, 1e-13);
 }
 
-TEST(DistributionsTest, SigmoidStretched) {
-	test_distribution("sigmoid_stretched", alfi::dist::Type::SIGMOID_STRETCHED, 1e-11);
+TEST(DistributionsTest, LogisticStretched) {
+	test_distribution("logistic_stretched", alfi::dist::Type::LOGISTIC_STRETCHED, 1e-11);
 }
 
 TEST(DistributionsTest, Erf) {


### PR DESCRIPTION
### Types of changes
- Refactoring, reformatting, cleanup
- Documentation

Related: #19 https://github.com/ALFI-lib/test_data/pull/2

### Description
Renamed `sigmoid` to `logistic` for a more accurate (literal) match to the concept.

The term `sigmoid` is often used to refer to the logistic function, but this is not entirely accurate because it covers a large variety of functions (e.g. erf, tanh, arctan).

**Examples:**
![examples: erf, tanh, arctan and others](https://upload.wikimedia.org/wikipedia/commons/6/6f/Gjl-t%28x%29.svg)

In this case, the term `logistic` is more appropriate.

**Standard logistic function:**
![standard logistic function](https://github.com/user-attachments/assets/8c5d3bbe-af88-4ad1-93b2-2dba47c39b63)

### Future improvements
The change eliminates semantic ambiguities, allowing more sigmoid functions to be implemented in the future.

### External links
https://en.wikipedia.org/wiki/Sigmoid_function
https://en.wikipedia.org/wiki/Logistic_function

https://ru.wikipedia.org/wiki/Сигмоида
https://ru.wikipedia.org/wiki/Логистическое_уравнение