### PR TITLE
Added `quadratic` and `cubic` distributions

### DIFF
--- a/ALFI/ALFI/dist.h
+++ b/ALFI/ALFI/dist.h
@@ -9,6 +9,8 @@ namespace alfi::dist {
 	enum class Type {
 		GENERAL,
 		UNIFORM,
+		QUADRATIC,
+		CUBIC,
 		CHEBYSHEV,
 		CHEBYSHEV_STRETCHED,
 		CHEBYSHEV_ELLIPSE,
@@ -28,6 +30,65 @@ namespace alfi::dist {
 		Container<Number> points(n);
 		for (SizeT i = 0; i < n; ++i) {
 			points[i] = a + (b - a) * static_cast<Number>(i) / static_cast<Number>(n - 1);
+		}
+		return points;
+	}
+
+	/**
+		@brief Generates a distribution of \p n points on the segment `[a, b]` using two quadratic polynomials.
+
+		The following transform function \f(f\f):
+		\f[
+			f(x) = \begin{cases}
+				(x+1)^2 - 1, & x \leq 0 \\
+				-(x-1)^2 + 1, & x > 0
+			\end{cases}
+		\f]
+		is applied to `n` points uniformly distributed on the segment `[-1, 1]`, mapping them onto the same segment.\n
+		The resulting points are then linearly mapped to the target segment `[a, b]`.
+
+		@param n number of points
+		@param a left boundary of the segment
+		@param b right boundary of the segment
+		@return a container with \p n points distributed on the segment `[a, b]` according to the transform function
+	*/
+	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	Container<Number> quadratic(SizeT n, Number a, Number b) {
+		if (n == 1)
+			return {(a+b)/2};
+		Container<Number> points(n);
+		for (SizeT i = 0; i < n; ++i) {
+			const Number x = 2 * static_cast<Number>(i) / (static_cast<Number>(n) - 1) - 1;
+			const Number value = x <= 0 ? x * (x + 2) : -x * (x - 2);
+			points[i] = a + (b - a) * (1 + value) / 2;
+		}
+		return points;
+	}
+
+	/**
+		@brief Generates a distribution of \p n points on the segment `[a, b]` using cubic polynomial.
+
+		The following transform function \f(f\f):
+		\f[
+			f(x) = -0.5x^3 + 1.5x
+		\f]
+		is applied to `n` points uniformly distributed on the segment `[-1, 1]`, mapping them onto the same segment.\n
+		The resulting points are then linearly mapped to the target segment `[a, b]`.
+
+		@param n number of points
+		@param a left boundary of the segment
+		@param b right boundary of the segment
+		@return a container with \p n points distributed on the segment `[a, b]` according to the transform function
+	*/
+	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	Container<Number> cubic(SizeT n, Number a, Number b) {
+		if (n == 1)
+			return {(a+b)/2};
+		Container<Number> points(n);
+		for (SizeT i = 0; i < n; ++i) {
+			const Number x = 2 * static_cast<Number>(i) / (static_cast<Number>(n) - 1) - 1;
+			const Number value = (3 - x*x) * x / 2;
+			points[i] = a + (b - a) * (1 + value) / 2;
 		}
 		return points;
 	}
@@ -195,6 +256,10 @@ namespace alfi::dist {
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
 	Container<Number> of_type(Type type, SizeT n, Number a, Number b, Number parameter = NAN) {
 		switch (type) {
+		case Type::QUADRATIC:
+			return quadratic(n, a, b);
+		case Type::CUBIC:
+			return cubic(n, a, b);
 		case Type::CHEBYSHEV:
 			return chebyshev(n, a, b);
 		case Type::CHEBYSHEV_STRETCHED:

--- a/examples/dist_QCustomPlot/dist_QCustomPlot.cpp
+++ b/examples/dist_QCustomPlot/dist_QCustomPlot.cpp
@@ -183,6 +183,8 @@ private:
 
 		const QVector<std::pair<QString, std::vector<double>>> distributions = {
 			{"Uniform", alfi::dist::uniform(n, a, b)},
+			{"Quadratic", alfi::dist::quadratic(n, a, b)},
+			{"Cubic", alfi::dist::cubic(n, a, b)},
 			{"Chebyshev", alfi::dist::chebyshev(n, a, b)},
 			{"Stretched Chebyshev", alfi::dist::chebyshev_stretched(n, a, b)},
 			{"Chebyshev Ellipse", alfi::dist::chebyshev_ellipse(n, a, b, B)},

--- a/examples/dist_gnuplot/dist_gnuplot.cpp
+++ b/examples/dist_gnuplot/dist_gnuplot.cpp
@@ -67,6 +67,8 @@ int main() {
 
 	plot_data({
 		{"Uniform", alfi::dist::uniform(n, a, b)},
+		{"Quadratic", alfi::dist::quadratic(n, a, b)},
+		{"Cubic", alfi::dist::cubic(n, a, b)},
 		{"Chebyshev", alfi::dist::chebyshev(n, a, b)},
 		{"Stretched Chebyshev", alfi::dist::chebyshev_stretched(n, a, b)},
 		{"Chebyshev Ellipse", alfi::dist::chebyshev_ellipse(n, a, b, ratio)},

--- a/examples/interpolation/interpolation.cpp
+++ b/examples/interpolation/interpolation.cpp
@@ -73,9 +73,9 @@ public:
 
 	PlotWindow() {
 		static const QStringList distribution_types {
-			"Uniform", "Chebyshev", "Chebyshev Stretched", "Chebyshev Ellipse", "Chebyshev Ellipse Stretched",
-			"Circle Projection", "Ellipse Projection", "Logistic", "Stretched Logistic",
-			"Error Function", "Stretched Error Function"
+			"Uniform", "Quadratic", "Cubic", "Chebyshev", "Stretched Chebyshev",
+			"Chebyshev Ellipse", "Stretched Chebyshev Ellipse", "Circle Projection", "Ellipse Projection",
+			"Logistic", "Stretched Logistic", "Error Function", "Stretched Error Function"
 		};
 
 		_plot = new QCustomPlot();
@@ -262,6 +262,8 @@ private:
 		std::vector<double> X;
 		switch (static_cast<alfi::dist::Type>(dist_type)) {
 			case alfi::dist::Type::UNIFORM: X = alfi::dist::uniform(N, a, b); break;
+			case alfi::dist::Type::QUADRATIC: X = alfi::dist::quadratic(N, a, b); break;
+			case alfi::dist::Type::CUBIC: X = alfi::dist::cubic(N, a, b); break;
 			case alfi::dist::Type::CHEBYSHEV: X = alfi::dist::chebyshev(N, a, b); break;
 			case alfi::dist::Type::CHEBYSHEV_STRETCHED: X = alfi::dist::chebyshev_stretched(N, a, b); break;
 			case alfi::dist::Type::CHEBYSHEV_ELLIPSE: X = alfi::dist::chebyshev_ellipse(N, a, b, 2.0); break;

--- a/tests/dist/test_dist.cpp
+++ b/tests/dist/test_dist.cpp
@@ -38,6 +38,14 @@ TEST(DistributionsTest, Uniform) {
 	test_distribution("uniform", alfi::dist::Type::UNIFORM, 1e-15);
 }
 
+TEST(DistributionsTest, Quadratic) {
+	test_distribution("quadratic", alfi::dist::Type::QUADRATIC, 1e-15);
+}
+
+TEST(DistributionsTest, Cubic) {
+	test_distribution("cubic", alfi::dist::Type::CUBIC, 1e-15);
+}
+
 TEST(DistributionsTest, Chebyshev) {
 	test_distribution("chebyshev", alfi::dist::Type::CHEBYSHEV, 1e-15);
 }


### PR DESCRIPTION
### Types of changes
- Feature
- Documentation
- Testing

Related: #19 https://github.com/ALFI-lib/test_data/pull/4

### Description
1. Declared `QUADRATIC` and `CUBIC` in `alfi::dist::Type`.
2. Added `quadratic` and `cubic` functions in `alfi::dist`.
4. Documented new functions.
5. Integrated into examples.
6. Covered with unit tests.

---

The **"quadratic" distribution** is given by:

$$
\mathrm{quadratic}(x) =
\begin{cases}
(x+1)^2 - 1, & x \leq 0 \\
-(x-1)^2 + 1, & x > 0
\end{cases}
$$

The **"cubic" distribution** is given by:

$$
\mathrm{cubic}(x) = -0.5x^3 + 1.5x
$$

The distribution of points is generated by applying these functions to the uniformly distributed points on the $[-1, 1]$ segment.

You can interact with these distributions on this Desmos graph: https://www.desmos.com/calculator/qdse58hzhp.