### PR TITLE
Added new quadratic spline types and unified calculations

### DIFF
--- a/ALFI/ALFI/spline/cubic.h
+++ b/ALFI/ALFI/spline/cubic.h
@@ -70,7 +70,7 @@ namespace alfi::spline {
 			 */
 			struct NotAKnotEnd final {};
 			/**
-				The arithmetic mean_array between NotAKnotStart and NotAKnotEnd.
+				The arithmetic mean of NotAKnotStart and NotAKnotEnd.
 			 */
 			struct SemiNotAKnot final {};
 			using Default = Natural;

--- a/examples/interpolation/interpolation.cpp
+++ b/examples/interpolation/interpolation.cpp
@@ -54,6 +54,17 @@ public:
 		{"Natural end", alfi::spline::QuadraticSpline<>::Types::NaturalEnd{}},
 		{"Semi-natural", alfi::spline::QuadraticSpline<>::Types::SemiNatural{}},
 		{"Semi-semi", alfi::spline::QuadraticSpline<>::Types::SemiSemi{}},
+		{"Clamped-start(10)", alfi::spline::QuadraticSpline<>::Types::ClampedStart{10}},
+		{"Clamped-start(-10)", alfi::spline::QuadraticSpline<>::Types::ClampedStart{-10}},
+		{"Clamped-end(10)", alfi::spline::QuadraticSpline<>::Types::ClampedEnd{10}},
+		{"Clamped-end(-10)", alfi::spline::QuadraticSpline<>::Types::ClampedEnd{-10}},
+		{"Semi-clamped(10, 10)", alfi::spline::QuadraticSpline<>::Types::SemiClamped{10, 10}},
+		{"Fixed-second-start(10)", alfi::spline::QuadraticSpline<>::Types::FixedSecondStart{10}},
+		{"Fixed-second-end(10)", alfi::spline::QuadraticSpline<>::Types::FixedSecondEnd{10}},
+		{"Semi-fixed-second(10, 10)", alfi::spline::QuadraticSpline<>::Types::SemiFixedSecond{10, 10}},
+		{"Clamped(10, 10)", alfi::spline::QuadraticSpline<>::Types::Clamped{10, 10}},
+		{"Fixed-second(10, 10)", alfi::spline::QuadraticSpline<>::Types::FixedSecond{10, 10}},
+		{"Not-a-knot(10)", alfi::spline::QuadraticSpline<>::Types::NotAKnot{10}},
 	};
 	static const inline size_t quadratic_spline_default_type_index = 2;
 


### PR DESCRIPTION
### Types of changes
- Feature

Related: #7 ALFI-lib/alfi-lib.github.io/pull/12

### Description
1. Added "ClampedStart", "ClampedEnd", "SemiClamped", "FixedSecondStart", "FixedSecondEnd", "SemiFixedSecond", "Clamped", "FixedSecond", and "NotAKnot" quadratic spline types.
2. Added minimal documentation for these types.
3. Unified calculations in `QuadraticSpline::compute_coeffs`.

### Future improvements
Possible future improvements are:
- Implement a simple way to get arithmetic means of various types.
- Implement periodic types.