### PR TITLE
Optimized and refactored `alfi::misc::barycentric`

### DIFF
--- a/ALFI/ALFI/misc.h
+++ b/ALFI/ALFI/misc.h
@@ -80,15 +80,13 @@ namespace alfi::misc {
 
 		Container<Number> result(nn);
 
-		const auto NOT_EXACT = N;
-
 		for (SizeT k = 0; k < nn; ++k) {
 			Number numerator = 0, denominator = 0;
-			SizeT exact = NOT_EXACT;
+			SizeT exact_idx = N;
 
 			for (SizeT i = 0; i < N; ++i) {
 				if (util::numeric::are_equal(xx[k], X[i], epsilon)) {
-					exact = i;
+					exact_idx = i;
 					break;
 				}
 				const auto x_diff = xx[k] - X[i];
@@ -97,8 +95,8 @@ namespace alfi::misc {
 				denominator += temp;
 			}
 
-			if (exact != NOT_EXACT) {
-				result[k] = Y[exact];
+			if (exact_idx != N) {
+				result[k] = Y[exact_idx];
 			} else {
 				result[k] = numerator / denominator;
 			}

--- a/ALFI/ALFI/misc.h
+++ b/ALFI/ALFI/misc.h
@@ -32,7 +32,7 @@ namespace alfi::misc {
 
 		const auto N = X.size();
 
-		Container c(N);
+		Container<Number> c(N);
 		if (dist_type == dist::Type::UNIFORM) {
 			c[0] = 1;
 			for (SizeT j = 1; j <= N / 2; ++j) {
@@ -78,31 +78,29 @@ namespace alfi::misc {
 
 		const auto nn = xx.size();
 
-		Container<Number> numerators(nn, static_cast<Number>(0));
-		Container<Number> denominators(nn, static_cast<Number>(0));
+		Container<Number> result(nn);
 
 		const auto NOT_EXACT = N;
-		Container<SizeT> exact(nn, NOT_EXACT);
 
-		for (SizeT k = 0; k < N; ++k) {
-			for (SizeT i = 0; i < nn; ++i) {
-				if (util::numeric::are_equal(xx[i], X[k], epsilon)) {
-					exact[i] = k;
-					continue;
+		for (SizeT k = 0; k < nn; ++k) {
+			Number numerator = 0, denominator = 0;
+			SizeT exact = NOT_EXACT;
+
+			for (SizeT i = 0; i < N; ++i) {
+				if (util::numeric::are_equal(xx[k], X[i], epsilon)) {
+					exact = i;
+					break;
 				}
-				const auto x_diff = xx[i] - X[k];
-				const auto temp = c[k] / x_diff;
-				numerators[i] += temp * Y[k];
-				denominators[i] += temp;
+				const auto x_diff = xx[k] - X[i];
+				const auto temp = c[i] / x_diff;
+				numerator += temp * Y[i];
+				denominator += temp;
 			}
-		}
 
-		Container<Number> result(nn, static_cast<Number>(0));
-		for (SizeT i = 0; i < nn; ++i) {
-			if (exact[i] != NOT_EXACT) {
-				result[i] = Y[exact[i]];
+			if (exact != NOT_EXACT) {
+				result[k] = Y[exact];
 			} else {
-				result[i] = numerators[i] / denominators[i];
+				result[k] = numerator / denominator;
 			}
 		}
 


### PR DESCRIPTION
### Types of changes
- Refactoring, reformatting, cleanup

Related: #5

### Description

1. Swapped loop nesting order to:
	- Reduce memory usage by removing intermediate containers (`numerators`,  `denominators`, and `exact`).
	- Allow parallelization by ensuring independent writes (`result[k] = `).

2. After swapping loops, changed the loop variable names for consistency with functions in `alfi::poly`:
	`k` for the outer loop and `i` for the inner one.

3. Small fix: changed `Container` to `Container<Number>` for `c` variable.

Note: in the previous implementation, if multiple elements `X[i]` were close to `xx[k]`, `result[k]` was set to `Y[i]` for the **last** suitable `i`. In the new implementation, it is set for the **first** suitable `i`.

### Future improvements
Implement parallelization.