### PR TITLE
fix: Changed `Container` to `Container<Number>` in `eval` in splines

### DIFF
--- a/ALFI/ALFI/spline/cubic.h
+++ b/ALFI/ALFI/spline/cubic.h
@@ -441,7 +441,7 @@ namespace alfi::spline {
 		}
 
 		Container<Number> eval(const Container<Number>& xx, bool sorted = true) const {
-			Container result(xx.size());
+			Container<Number> result(xx.size());
 			if (sorted) {
 				for (SizeT i = 0, i_x = 0; i < xx.size(); ++i) {
 					const Number evalx = xx[i];

--- a/ALFI/ALFI/spline/linear.h
+++ b/ALFI/ALFI/spline/linear.h
@@ -91,7 +91,7 @@ namespace alfi::spline {
 		}
 
 		Container<Number> eval(const Container<Number>& xx, bool sorted = true) const {
-			Container result(xx.size());
+			Container<Number> result(xx.size());
 			if (sorted) {
 				for (SizeT i = 0, i_x = 0; i < xx.size(); ++i) {
 					const Number x = xx[i];

--- a/ALFI/ALFI/spline/quadratic.h
+++ b/ALFI/ALFI/spline/quadratic.h
@@ -310,7 +310,7 @@ namespace alfi::spline {
 		}
 
 		Container<Number> eval(const Container<Number>& xx, bool sorted = true) const {
-			Container result(xx.size());
+			Container<Number> result(xx.size());
 			if (sorted) {
 				for (SizeT i = 0, i_x = 0; i < xx.size(); ++i) {
 					const Number evalx = xx[i];

--- a/ALFI/ALFI/spline/step.h
+++ b/ALFI/ALFI/spline/step.h
@@ -86,7 +86,7 @@ namespace alfi::spline {
 		}
 
 		Container<Number> eval(const Container<Number>& xx, bool sorted = true) const {
-			Container result(xx.size());
+			Container<Number> result(xx.size());
 			if (sorted) {
 				for (SizeT i = 0, i_x = 0; i < xx.size(); ++i) {
 					const Number x = xx[i];


### PR DESCRIPTION
### Types of changes
- Bug fix

### Description
Specialized the template parameter `Container` for type `Number`.
Not sure why it worked before.