### PR TITLE
Added OpenMP support for `barycentric` and `*_vals` functions

### DIFF
--- a/.idea/cmake.xml
+++ b/.idea/cmake.xml
@@ -7,6 +7,7 @@
       <configuration PROFILE_NAME="RelWithDebInfo" ENABLED="true" GENERATION_DIR="build/relwithdebinfo" CONFIG_NAME="RelWithDebInfo" />
       <configuration PROFILE_NAME="MinSizeRel" ENABLED="true" GENERATION_DIR="build/minsizerel" CONFIG_NAME="MinSizeRel" />
       <configuration PROFILE_NAME="Fast" ENABLED="true" GENERATION_DIR="build/fast" CONFIG_NAME="Fast" />
+      <configuration PROFILE_NAME="FastParallel" ENABLED="true" GENERATION_DIR="build/fastparallel" CONFIG_NAME="FastParallel" />
       <configuration PROFILE_NAME="Sanitize" ENABLED="true" GENERATION_DIR="build/sanitize" CONFIG_NAME="Sanitize" />
     </configurations>
   </component>

--- a/ALFI/ALFI/misc.h
+++ b/ALFI/ALFI/misc.h
@@ -80,6 +80,9 @@ namespace alfi::misc {
 
 		Container<Number> result(nn);
 
+#if defined(_OPENMP) && !defined(ALFI_DISABLE_OPENMP)
+#pragma omp parallel for
+#endif
 		for (SizeT k = 0; k < nn; ++k) {
 			Number numerator = 0, denominator = 0;
 			SizeT exact_idx = N;

--- a/ALFI/ALFI/poly.h
+++ b/ALFI/ALFI/poly.h
@@ -100,6 +100,9 @@ namespace alfi::poly {
 
 		Container<Number> yy(nn);
 
+#if defined(_OPENMP) && !defined(ALFI_DISABLE_OPENMP)
+#pragma omp parallel for
+#endif
 		for (SizeT k = 0; k < nn; ++k) {
 			yy[k] = 0;
 			for (SizeT i = 0; i < N; ++i) {
@@ -212,6 +215,9 @@ namespace alfi::poly {
 
 		Container<Number> yy(nn);
 
+#if defined(_OPENMP) && !defined(ALFI_DISABLE_OPENMP)
+#pragma omp parallel for
+#endif
 		for (SizeT k = 0; k < nn; ++k) {
 			Number l = 1;
 			for (SizeT i = 0; i < N; ++i) {
@@ -318,6 +324,9 @@ namespace alfi::poly {
 
 		Container<Number> yy(nn);
 
+#if defined(_OPENMP) && !defined(ALFI_DISABLE_OPENMP)
+#pragma omp parallel for
+#endif
 		for (SizeT k = 0; k < nn; ++k) {
 			yy[k] = F[N-1];
 			for (SizeT iter = 0; iter < N - 1; ++iter) {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "-g0 -s -O3 -flto=auto -DNDEBUG")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g3 -O2 -flto=auto -DNDEBUG")
 set(CMAKE_CXX_FLAGS_MINSIZEREL "-g0 -s -Oz -flto=auto -DNDEBUG")
 set(CMAKE_CXX_FLAGS_FAST "-g0 -s -Ofast -flto=auto -DNDEBUG")
+set(CMAKE_CXX_FLAGS_FASTPARALLEL "-g0 -s -Ofast -flto=auto -fopenmp -DNDEBUG")
 set(CMAKE_CXX_FLAGS_SANITIZE "-g3 -fsanitize=address,leak,undefined")
 
 add_subdirectory(ALFI)

--- a/helper.py
+++ b/helper.py
@@ -9,6 +9,7 @@ profile_directories = {
 	'RelWithDebInfo': 'build/relwithdebinfo',
 	'MinSizeRel': 'build/minsizerel',
 	'Fast': 'build/fast',
+	'FastParallel': 'build/fastparallel',
 	'Sanitize': 'build/sanitize',
 }
 


### PR DESCRIPTION
### Types of changes
- Feature

Related: #13 #32

### Description
1. Added OpenMP support for `alfi::misc::barycentric` and `alfi::poly::*_vals` functions.
2. Introduced `ALFI_DISABLE_OPENMP` macro to disable the use of OpenMP in ALFI when compiling with `-fopenmp` option.

> [!NOTE]
> The use of OpenMP is enabled by default if the `-fopenmp` option is used, because it is assumed that if the user compiles a program with this option, he intends to use OpenMP functionality.

3. Added `FastParallel` CMake profile with `-fopenmp` option.

### Future improvements
Implement GPU parallelization.