### PR TITLE
Switched to minimal toml++ repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "tests/deps/toml++"]
 	path = tests/deps/toml++
-	url = https://github.com/marzer/tomlplusplus
+	url = https://github.com/pasabanov/tomlpp-min
 	shallow = true
 [submodule "tests/test_data"]
 	path = tests/test_data

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,14 +1,14 @@
 set(CMAKE_CXX_STANDARD 23)
 
 find_package(GTest REQUIRED)
-add_subdirectory(deps/toml++)
 
+set(DEPS_DIR "${CMAKE_CURRENT_LIST_DIR}/deps")
 set(TEST_DATA_DIR "${CMAKE_CURRENT_LIST_DIR}/test_data")
 
 macro(add_test_executable test_name)
 	add_executable(${test_name} ${ARGN} test_utils.h)
-	target_include_directories(${test_name} PRIVATE ${GTEST_INCLUDE_DIRS})
-	target_link_libraries(${test_name} PRIVATE ALFI GTest::GTest GTest::Main tomlplusplus::tomlplusplus)
+	target_include_directories(${test_name} PRIVATE ${GTEST_INCLUDE_DIRS} ${DEPS_DIR})
+	target_link_libraries(${test_name} PRIVATE ALFI GTest::GTest GTest::Main)
 	target_compile_options(${test_name} PRIVATE -fsanitize=address,leak,undefined)
 	target_link_options(${test_name} PRIVATE -fsanitize=address,leak,undefined)
 	target_compile_definitions(${test_name} PRIVATE TEST_DATA_DIR="${TEST_DATA_DIR}")


### PR DESCRIPTION
### Types of changes
- Dependency version updates
- Configuration (submodule, build)

Related: #19

### Description
Switched to minimal toml++ repository https://github.com/pasabanov/tomlpp-min instead of https://github.com/marzer/tomlplusplus.
Current toml++ version: https://github.com/pasabanov/tomlpp-min/releases/tag/v3.4.0.