### PR TITLE
Removed `auto` from parameters and refactored

### DIFF
--- a/ALFI/ALFI/dist.h
+++ b/ALFI/ALFI/dist.h
@@ -107,7 +107,7 @@ namespace alfi::dist {
 
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
 	Container<Number> chebyshev_stretched(SizeT n, Number a, Number b) {
-		return points::stretched(chebyshev(n, a, b), a, b);
+		return points::stretched<Number,Container>(chebyshev(n, a, b), a, b);
 	}
 
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
@@ -126,7 +126,7 @@ namespace alfi::dist {
 
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
 	Container<Number> chebyshev_ellipse_stretched(SizeT n, Number a, Number b, Number ratio) {
-		return points::stretched(chebyshev_ellipse(n, a, b, ratio), a, b);
+		return points::stretched<Number,Container>(chebyshev_ellipse(n, a, b, ratio), a, b);
 	}
 
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
@@ -250,7 +250,7 @@ namespace alfi::dist {
 
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
 	Container<Number> erf_stretched(SizeT n, Number a, Number b, Number steepness) {
-		return points::stretched(erf(n, a, b, steepness), a, b);
+		return points::stretched<Number,Container>(erf(n, a, b, steepness), a, b);
 	}
 
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>

--- a/ALFI/ALFI/misc.h
+++ b/ALFI/ALFI/misc.h
@@ -10,9 +10,9 @@ namespace alfi::misc {
 
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
 	Container<Number> barycentric(
-			const auto& X,
-			const auto& Y,
-			const auto& xx,
+			const Container<Number>& X,
+			const Container<Number>& Y,
+			const Container<Number>& xx,
 			dist::Type dist_type = dist::Type::GENERAL,
 			Number epsilon = std::numeric_limits<Number>::epsilon()
 	) {

--- a/ALFI/ALFI/poly.h
+++ b/ALFI/ALFI/poly.h
@@ -7,9 +7,9 @@
 #include "util/numeric.h"
 
 namespace alfi::poly {
-	template <typename Number = DefaultNumber>
+	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
 	std::enable_if_t<!traits::has_size<Number>::value, Number>
-	val(const auto& coeffs, Number x) {
+	val(const Container<Number>& coeffs, Number x) {
 		Number result = 0;
 		for (const Number& c : coeffs) {
 			result = x * result + c;
@@ -17,9 +17,9 @@ namespace alfi::poly {
 		return result;
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer, typename ContainerX = Container<Number>>
-	std::enable_if_t<traits::has_size<ContainerX>::value, Container<Number>>
-	val(const auto& coeffs, const ContainerX& X) {
+	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	std::enable_if_t<traits::has_size<Container<Number>>::value, Container<Number>>
+	val(const Container<Number>& coeffs, const Container<Number>& X) {
 		Container<Number> result(X.size(), 0);
 #if defined(_OPENMP) && !defined(ALFI_DISABLE_OPENMP)
 #pragma omp parallel for
@@ -33,7 +33,7 @@ namespace alfi::poly {
 	}
 
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
-	Container<Number> lagrange(const auto& X, const auto& Y) {
+	Container<Number> lagrange(const Container<Number>& X, const Container<Number>& Y) {
 		if (X.size() != Y.size()) {
 			std::cerr << "Error in function " << __FUNCTION__
 					  << ": Vectors X (of size " << X.size()
@@ -78,7 +78,7 @@ namespace alfi::poly {
 	}
 
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
-	Container<Number> lagrange_vals(const auto& X, const auto& Y, const auto& xx) {
+	Container<Number> lagrange_vals(const Container<Number>& X, const Container<Number>& Y, const Container<Number>& xx) {
 		const auto nn = xx.size();
 
 		if (X.size() != Y.size()) {
@@ -123,7 +123,7 @@ namespace alfi::poly {
 	}
 
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
-	Container<Number> imp_lagrange(const auto& X, const auto& Y) {
+	Container<Number> imp_lagrange(const Container<Number>& X, const Container<Number>& Y) {
 		if (X.size() != Y.size()) {
 			std::cerr << "Error in function " << __FUNCTION__
 					  << ": Vectors X (of size " << X.size()
@@ -183,7 +183,12 @@ namespace alfi::poly {
 	}
 
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
-	Container<Number> imp_lagrange_vals(const auto& X, const auto& Y, const auto& xx, Number epsilon = std::numeric_limits<Number>::epsilon()) {
+	Container<Number> imp_lagrange_vals(
+			const Container<Number>& X,
+			const Container<Number>& Y,
+			const Container<Number>& xx,
+			Number epsilon = std::numeric_limits<Number>::epsilon()
+	) {
 		const auto nn = xx.size();
 
 		if (X.size() != Y.size()) {
@@ -241,7 +246,7 @@ namespace alfi::poly {
 	}
 
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
-	Container<Number> newton(const auto& X, const auto& Y) {
+	Container<Number> newton(const Container<Number>& X, const Container<Number>& Y) {
 		if (X.size() != Y.size()) {
 			std::cerr << "Error in function " << __FUNCTION__
 					  << ": Vectors X (of size " << X.size()
@@ -294,7 +299,7 @@ namespace alfi::poly {
 	}
 
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
-	Container<Number> newton_vals(const auto& X, const auto& Y, const auto& xx) {
+	Container<Number> newton_vals(const Container<Number>& X, const Container<Number>& Y, const Container<Number>& xx) {
 		const auto nn = xx.size();
 
 		if (X.size() != Y.size()) {

--- a/ALFI/ALFI/spline/linear.h
+++ b/ALFI/ALFI/spline/linear.h
@@ -11,7 +11,7 @@ namespace alfi::spline {
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
 	class LinearSpline {
 	public:
-		static Container<Number> compute_coeffs(const auto& X, const auto& Y) {
+		static Container<Number> compute_coeffs(const Container<Number>& X, const Container<Number>& Y) {
 			if (X.size() != Y.size()) {
 				std::cerr << "Error in function " << __FUNCTION__
 						  << ": Vectors X (of size " << X.size()
@@ -47,7 +47,7 @@ namespace alfi::spline {
 		LinearSpline() = default;
 
 		template <typename ContainerXType>
-		LinearSpline(ContainerXType&& X, const auto& Y) {
+		LinearSpline(ContainerXType&& X, const Container<Number>& Y) {
 			construct(std::forward<ContainerXType>(X), Y);
 		}
 
@@ -58,7 +58,7 @@ namespace alfi::spline {
 		LinearSpline& operator=(LinearSpline&& other) noexcept = default;
 
 		template <typename ContainerXType>
-		void construct(ContainerXType&& X, const auto& Y) {
+		void construct(ContainerXType&& X, const Container<Number>& Y) {
 			if (X.size() != Y.size()) {
 				std::cerr << "Error in function " << __FUNCTION__
 						  << ": Vectors X (of size " << X.size()

--- a/ALFI/ALFI/spline/quadratic.h
+++ b/ALFI/ALFI/spline/quadratic.h
@@ -134,7 +134,7 @@ namespace alfi::spline {
 								  typename Types::FixedSecond,
 								  typename Types::NotAKnot>;
 
-		static Container<Number> compute_coeffs(const auto& X, const auto& Y, Type type = typename Types::Default{}) {
+		static Container<Number> compute_coeffs(const Container<Number>& X, const Container<Number>& Y, Type type = typename Types::Default{}) {
 			if (X.size() != Y.size()) {
 				std::cerr << "Error in function " << __FUNCTION__
 						  << ": Vectors X (of size " << X.size()
@@ -265,7 +265,7 @@ namespace alfi::spline {
 		QuadraticSpline() = default;
 
 		template <typename ContainerXType>
-		QuadraticSpline(ContainerXType&& X, const auto& Y, Type type = typename Types::Default{}) {
+		QuadraticSpline(ContainerXType&& X, const Container<Number>& Y, Type type = typename Types::Default{}) {
 			construct(std::forward<ContainerXType>(X), Y, type);
 		}
 
@@ -276,7 +276,7 @@ namespace alfi::spline {
 		QuadraticSpline& operator=(QuadraticSpline&& other) noexcept = default;
 
 		template <typename ContainerXType>
-		void construct(ContainerXType&& X, const auto& Y, Type type = typename Types::Default{}) {
+		void construct(ContainerXType&& X, const Container<Number>& Y, Type type = typename Types::Default{}) {
 			if (X.size() != Y.size()) {
 				std::cerr << "Error in function " << __FUNCTION__
 						  << ": Vectors X (of size " << X.size()

--- a/ALFI/ALFI/util/arrays.h
+++ b/ALFI/ALFI/util/arrays.h
@@ -40,7 +40,7 @@ namespace alfi::util::arrays {
 	}
 
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
-	Container<Number> diff(const auto& container) {
+	Container<Number> diff(const Container<Number>& container) {
 		if (container.empty()) {
 			return {};
 		}

--- a/ALFI/ALFI/util/linalg.h
+++ b/ALFI/ALFI/util/linalg.h
@@ -98,7 +98,12 @@ namespace alfi::util::linalg {
 		@return the solution vector
 	 */
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
-	Container<Number> tridiag_solve_unstable(const auto& lower, auto&& diag, const auto& upper, auto&& right) {
+	Container<Number> tridiag_solve_unstable(
+			const Container<Number>& lower,
+			Container<Number>&& diag,
+			const Container<Number>& upper,
+			Container<Number>&& right
+	) {
 		const auto n = right.size();
 		assert(n == lower.size());
 		assert(n == diag.size());
@@ -140,7 +145,12 @@ namespace alfi::util::linalg {
 		@return the solution vector
 	 */
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
-	Container<Number> tridiag_solve(auto&& lower, auto&& diag, auto&& upper, auto&& right) {
+	Container<Number> tridiag_solve(
+			Container<Number>&& lower,
+			Container<Number>&& diag,
+			Container<Number>&& upper,
+			Container<Number>&& right
+	) {
 		const auto n = right.size();
 		assert(n == lower.size());
 		assert(n == diag.size());

--- a/ALFI/ALFI/util/points.h
+++ b/ALFI/ALFI/util/points.h
@@ -16,7 +16,7 @@ namespace alfi::points {
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
 	Container<Number> lin_mapped(const Container<Number>& points, Number a, Number b, Number c, Number d) {
 		auto mapped_points = points;
-		lin_map(mapped_points, a, b, c, d);
+		lin_map<Number,Container>(mapped_points, a, b, c, d);
 		return mapped_points;
 	}
 
@@ -29,7 +29,7 @@ namespace alfi::points {
 			std::fill(points.begin(), points.end(), (a + b) / 2);
 			return;
 		}
-		lin_map(points, points.front(), points.back(), a, b);
+		lin_map<Number,Container>(points, points.front(), points.back(), a, b);
 		points.front() = a;
 		points.back() = b;
 	}
@@ -37,7 +37,7 @@ namespace alfi::points {
 	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
 	Container<Number> stretched(const Container<Number>& points, Number a, Number b) {
 		auto stretched_points = points;
-		stretch(stretched_points, a, b);
+		stretch<Number,Container>(stretched_points, a, b);
 		return stretched_points;
 	}
 }

--- a/ALFI/ALFI/util/points.h
+++ b/ALFI/ALFI/util/points.h
@@ -3,8 +3,8 @@
 #include "../config.h"
 
 namespace alfi::points {
-	template <typename Number = DefaultNumber>
-	void lin_map(auto& points, Number a, Number b, Number c, Number d) {
+	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	void lin_map(Container<Number>& points, Number a, Number b, Number c, Number d) {
 		const auto mid1 = (a + b) / 2;
 		const auto mid2 = (c + d) / 2;
 		const auto scale = (d - c) / (b - a);
@@ -13,15 +13,15 @@ namespace alfi::points {
 		}
 	}
 
-	template <typename Number = DefaultNumber>
-	auto lin_mapped(const auto& points, Number a, Number b, Number c, Number d) {
+	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	Container<Number> lin_mapped(const Container<Number>& points, Number a, Number b, Number c, Number d) {
 		auto mapped_points = points;
 		lin_map(mapped_points, a, b, c, d);
 		return mapped_points;
 	}
 
-	template <typename Number = DefaultNumber>
-	void stretch(auto& points, Number a, Number b) {
+	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	void stretch(Container<Number>& points, Number a, Number b) {
 		if (points.empty()) {
 			return;
 		}
@@ -34,8 +34,8 @@ namespace alfi::points {
 		points.back() = b;
 	}
 
-	template <typename Number = DefaultNumber>
-	auto stretched(const auto& points, Number a, Number b) {
+	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	Container<Number> stretched(const Container<Number>& points, Number a, Number b) {
 		auto stretched_points = points;
 		stretch(stretched_points, a, b);
 		return stretched_points;

--- a/ALFI/ALFI/util/spline.h
+++ b/ALFI/ALFI/util/spline.h
@@ -65,7 +65,7 @@ namespace alfi::util::spline {
 			const auto h12 = X[2]-X[0], h13 = X[3]-X[0];
 			const auto d1 = Y[1]-Y[0], d12 = Y[2]-Y[0], d13 = Y[3]-Y[0];
 
-			const auto abc = util::linalg::lup_solve(
+			const auto abc = linalg::lup_solve<Number,Container>(
 				{{std::pow(h1, 3), std::pow(h1, 2), h1},
 					{std::pow(h12, 3), std::pow(h12, 2), h12},
 					{std::pow(h13, 3), std::pow(h13, 2), h13}},

--- a/examples/dist_QCustomPlot/CMakeLists.txt
+++ b/examples/dist_QCustomPlot/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 17)
 
 find_package(Qt5 REQUIRED COMPONENTS Widgets)
 find_package(QCustomPlot REQUIRED)

--- a/examples/dist_gnuplot/CMakeLists.txt
+++ b/examples/dist_gnuplot/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 17)
 
 find_package(Boost REQUIRED COMPONENTS iostreams)
 find_package(Gnuplot REQUIRED)

--- a/examples/interpolation/CMakeLists.txt
+++ b/examples/interpolation/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 20)
 
 find_package(Qt5 REQUIRED COMPONENTS Widgets)
 find_package(QCustomPlot REQUIRED)

--- a/examples/interpolation/interpolation.cpp
+++ b/examples/interpolation/interpolation.cpp
@@ -30,11 +30,11 @@ class PlotWindow final : public QWidget {
 public:
 	static const inline std::vector<std::pair<QString,std::function<std::vector<double>(std::vector<double>,std::vector<double>,std::vector<double>)>>>
 	poly_types = {
-		{"Lagrange", [](const auto& X, const auto& Y, const auto& xx) { return alfi::poly::val(alfi::poly::lagrange(X, Y), xx); }},
+		{"Lagrange", [](const auto& X, const auto& Y, const auto& xx) { return alfi::poly::val<double,std::vector>(alfi::poly::lagrange(X, Y), xx); }},
 		{"Lagrange values", [](const auto& X, const auto& Y, const auto& xx) { return alfi::poly::lagrange_vals(X, Y, xx); }},
-		{"Improved Lagrange", [](const auto& X, const auto& Y, const auto& xx) { return alfi::poly::val(alfi::poly::imp_lagrange(X, Y), xx); }},
+		{"Improved Lagrange", [](const auto& X, const auto& Y, const auto& xx) { return alfi::poly::val<double,std::vector>(alfi::poly::imp_lagrange(X, Y), xx); }},
 		{"Improved Lagrange values", [](const auto& X, const auto& Y, const auto& xx) { return alfi::poly::imp_lagrange_vals(X, Y, xx); }},
-		{"Newton", [](const auto& X, const auto& Y, const auto& xx) { return alfi::poly::val(alfi::poly::newton(X, Y), xx); }},
+		{"Newton", [](const auto& X, const auto& Y, const auto& xx) { return alfi::poly::val<double,std::vector>(alfi::poly::newton(X, Y), xx); }},
 		{"Newton values", [](const auto& X, const auto& Y, const auto& xx) { return alfi::poly::newton_vals(X, Y, xx); }},
 	};
 	static const inline size_t poly_default_type_index = 0;
@@ -332,19 +332,19 @@ private:
 			if (barycentric_dist_type == 0) {
 				barycentric_dist_type = dist_type;
 			}
-			add_graph("Barycentric", xx, alfi::misc::barycentric(X, Y, xx, static_cast<alfi::dist::Type>(barycentric_dist_type)));
+			add_graph("Barycentric", xx, alfi::misc::barycentric<double,std::vector>(X, Y, xx, static_cast<alfi::dist::Type>(barycentric_dist_type)));
 		}
 		if (_step_spline_checkbox->isChecked()) {
 			add_graph("Step Spline", xx, alfi::spline::StepSpline(X, Y, step_spline_types[_step_spline_combo->currentIndex()].second)(xx));
 		}
 		if (_linear_spline_checkbox->isChecked()) {
-			add_graph("Linear Spline", xx, alfi::spline::LinearSpline(X, Y)(xx));
+			add_graph("Linear Spline", xx, alfi::spline::LinearSpline<>(X, Y)(xx));
 		}
 		if (_quadratic_spline_checkbox->isChecked()) {
-			add_graph("Quadratic Spline", xx, alfi::spline::QuadraticSpline(X, Y, quadratic_spline_types[_quadratic_spline_combo->currentIndex()].second)(xx));
+			add_graph("Quadratic Spline", xx, alfi::spline::QuadraticSpline<>(X, Y, quadratic_spline_types[_quadratic_spline_combo->currentIndex()].second)(xx));
 		}
 		if (_cubic_spline_checkbox->isChecked()) {
-			add_graph("Cubic Spline", xx, alfi::spline::CubicSpline(X, Y, cubic_spline_types[_cubic_spline_combo->currentIndex()].second)(xx));
+			add_graph("Cubic Spline", xx, alfi::spline::CubicSpline<>(X, Y, cubic_spline_types[_cubic_spline_combo->currentIndex()].second)(xx));
 		}
 
 		if (_default_axis_ranges) {

--- a/tests/dist/test_dist.cpp
+++ b/tests/dist/test_dist.cpp
@@ -27,7 +27,7 @@ void test_distribution(const char*const name, const alfi::dist::Type type, doubl
 		mapping_intervals.for_each([&](const toml::array& interval) {
 			const auto c = interval[0].value<double>().value();
 			const auto d = interval[1].value<double>().value();
-			const auto mapped_expected = alfi::points::lin_mapped(expected, a, b, c, d);
+			const auto mapped_expected = alfi::points::lin_mapped<double,std::vector>(expected, a, b, c, d);
 			const auto mapped_generated = of_type(type, n, c, d, parameter);
 			expect_eq(mapped_generated, mapped_expected, epsilon);
 		});


### PR DESCRIPTION
### Types of changes
- Bug fix
- Refactoring, reformatting, cleanup

Related: #7
Resolves #36

### Description
1. Changed `auto` in parameter declarations to `Container<Number>` in all problematic functions from #36 to comply with the C++17 standard.

2. Added `<Number,Container>` specification to uses of `tridiag_solve` and `lup_solve`.

3. **Had to** apply `std::move` to the `lower`, `diag`, `upper` and `right` variables when passed to `tridiag_solve`. I think, this is a bug fix.

4. Lowered `CMAKE_CXX_STANDARD` for examples: 17 for dist_gnuplot and dist_QCustomPlot, and 20 for interpolation.

5. Had to add some type specification in interpolation example.

> [!NOTE]
> The most important specifications are [`QuadraticSpline<>`](https://github.com/ALFI-lib/ALFI/pull/38/files#diff-f5ed3e9ceb6fb0051fe5ed8264b414eeda3001c7bafbf84ecc45248ca7d0dabcR344) and [`CubicSpline<>`](https://github.com/ALFI-lib/ALFI/pull/38/files#diff-f5ed3e9ceb6fb0051fe5ed8264b414eeda3001c7bafbf84ecc45248ca7d0dabcR347).
> The others like [`alfi::poly::val<double,std::vector>`](https://github.com/ALFI-lib/ALFI/pull/38/files#diff-f5ed3e9ceb6fb0051fe5ed8264b414eeda3001c7bafbf84ecc45248ca7d0dabcR33), [`LinearSpline<>`](https://github.com/ALFI-lib/ALFI/pull/38/files#diff-f5ed3e9ceb6fb0051fe5ed8264b414eeda3001c7bafbf84ecc45248ca7d0dabcR341), and [`alfi::misc::barycentric<double,std::vector>`](https://github.com/ALFI-lib/ALFI/pull/38/files#diff-f5ed3e9ceb6fb0051fe5ed8264b414eeda3001c7bafbf84ecc45248ca7d0dabcR335) don't lead to a compile errors, but lead to CLion's linter errors.

### Future improvements
Change `template <typename> class Container` to `template <typename, typename...> class Container` to improve the Template Argument Deduction.