### PR TITLE
Changed `Container` from `template <typename>` to `template <typename, typename...>`

### DIFF
--- a/ALFI/ALFI/config.h
+++ b/ALFI/ALFI/config.h
@@ -16,8 +16,8 @@
 namespace alfi {
 	using DefaultNumber = ALFI_DEFAULT_NUMBER;
 
-	template <typename Number = DefaultNumber>
-	using DefaultContainer = ALFI_DEFAULT_CONTAINER<Number>;
+	template <typename Number = DefaultNumber, typename... Ts>
+	using DefaultContainer = ALFI_DEFAULT_CONTAINER<Number, Ts...>;
 
 	using SizeT = ALFI_SIZE_TYPE;
 

--- a/ALFI/ALFI/dist.h
+++ b/ALFI/ALFI/dist.h
@@ -23,7 +23,7 @@ namespace alfi::dist {
 		ERF_STRETCHED,
 	};
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> uniform(SizeT n, Number a, Number b) {
 		if (n == 1)
 			return {(a+b)/2};
@@ -52,7 +52,7 @@ namespace alfi::dist {
 		@param b right boundary of the segment
 		@return a container with \p n points distributed on the segment `[a, b]` according to the transform function
 	*/
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> quadratic(SizeT n, Number a, Number b) {
 		if (n == 1)
 			return {(a+b)/2};
@@ -80,7 +80,7 @@ namespace alfi::dist {
 		@param b right boundary of the segment
 		@return a container with \p n points distributed on the segment `[a, b]` according to the transform function
 	*/
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> cubic(SizeT n, Number a, Number b) {
 		if (n == 1)
 			return {(a+b)/2};
@@ -93,7 +93,7 @@ namespace alfi::dist {
 		return points;
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> chebyshev(SizeT n, Number a, Number b) {
 		if (n == 1)
 			return {(a+b)/2};
@@ -105,12 +105,12 @@ namespace alfi::dist {
 		return points;
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> chebyshev_stretched(SizeT n, Number a, Number b) {
 		return points::stretched<Number,Container>(chebyshev(n, a, b), a, b);
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> chebyshev_ellipse(SizeT n, Number a, Number b, Number ratio) {
 		Container<Number> points(n);
 		for (SizeT i = 0; i < n / 2; ++i) {
@@ -124,12 +124,12 @@ namespace alfi::dist {
 		return points;
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> chebyshev_ellipse_stretched(SizeT n, Number a, Number b, Number ratio) {
 		return points::stretched<Number,Container>(chebyshev_ellipse(n, a, b, ratio), a, b);
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> circle_proj(SizeT n, Number a, Number b) {
 		if (n == 1)
 			return {(a+b)/2};
@@ -141,7 +141,7 @@ namespace alfi::dist {
 		return points;
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> ellipse_proj(SizeT n, Number a, Number b, Number ratio) {
 		Container<Number> points(n);
 		for (SizeT i = 0; i < n / 2; ++i) {
@@ -178,7 +178,7 @@ namespace alfi::dist {
 		@param steepness determines the slope of the transform function at `x = 0`
 		@return a container with \p n points distributed on the interval `(a, b)` according to the transform function
 	*/
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> logistic(SizeT n, Number a, Number b, Number steepness) {
 		if (n == 1)
 			return {(a+b)/2};
@@ -191,7 +191,7 @@ namespace alfi::dist {
 		return points;
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> logistic_stretched(SizeT n, Number a, Number b, Number steepness) {
 		if (n == 0)
 			return {};
@@ -233,7 +233,7 @@ namespace alfi::dist {
 		@param steepness determines the slope of the transform function at `x = 0`
 		@return a container with \p n points distributed on the interval `(a, b)` according to the transform function
 	*/
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> erf(SizeT n, Number a, Number b, Number steepness) {
 		if (n == 0)
 			return {};
@@ -248,12 +248,12 @@ namespace alfi::dist {
 		return points;
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> erf_stretched(SizeT n, Number a, Number b, Number steepness) {
 		return points::stretched<Number,Container>(erf(n, a, b, steepness), a, b);
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> of_type(Type type, SizeT n, Number a, Number b, Number parameter = NAN) {
 		switch (type) {
 		case Type::QUADRATIC:

--- a/ALFI/ALFI/misc.h
+++ b/ALFI/ALFI/misc.h
@@ -8,7 +8,7 @@
 
 namespace alfi::misc {
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> barycentric(
 			const Container<Number>& X,
 			const Container<Number>& Y,

--- a/ALFI/ALFI/poly.h
+++ b/ALFI/ALFI/poly.h
@@ -7,7 +7,7 @@
 #include "util/numeric.h"
 
 namespace alfi::poly {
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	std::enable_if_t<!traits::has_size<Number>::value, Number>
 	val(const Container<Number>& coeffs, Number x) {
 		Number result = 0;
@@ -17,7 +17,7 @@ namespace alfi::poly {
 		return result;
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	std::enable_if_t<traits::has_size<Container<Number>>::value, Container<Number>>
 	val(const Container<Number>& coeffs, const Container<Number>& X) {
 		Container<Number> result(X.size(), 0);
@@ -32,7 +32,7 @@ namespace alfi::poly {
 		return result;
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> lagrange(const Container<Number>& X, const Container<Number>& Y) {
 		if (X.size() != Y.size()) {
 			std::cerr << "Error in function " << __FUNCTION__
@@ -77,7 +77,7 @@ namespace alfi::poly {
 		return P;
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> lagrange_vals(const Container<Number>& X, const Container<Number>& Y, const Container<Number>& xx) {
 		const auto nn = xx.size();
 
@@ -122,7 +122,7 @@ namespace alfi::poly {
 		return yy;
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> imp_lagrange(const Container<Number>& X, const Container<Number>& Y) {
 		if (X.size() != Y.size()) {
 			std::cerr << "Error in function " << __FUNCTION__
@@ -182,7 +182,7 @@ namespace alfi::poly {
 		return P;
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> imp_lagrange_vals(
 			const Container<Number>& X,
 			const Container<Number>& Y,
@@ -245,7 +245,7 @@ namespace alfi::poly {
 		return yy;
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> newton(const Container<Number>& X, const Container<Number>& Y) {
 		if (X.size() != Y.size()) {
 			std::cerr << "Error in function " << __FUNCTION__
@@ -298,7 +298,7 @@ namespace alfi::poly {
 		return P;
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> newton_vals(const Container<Number>& X, const Container<Number>& Y, const Container<Number>& xx) {
 		const auto nn = xx.size();
 

--- a/ALFI/ALFI/spline/cubic.h
+++ b/ALFI/ALFI/spline/cubic.h
@@ -11,7 +11,7 @@
 #include "../util/spline.h"
 
 namespace alfi::spline {
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	class CubicSpline {
 	public:
 		struct Types final {

--- a/ALFI/ALFI/spline/linear.h
+++ b/ALFI/ALFI/spline/linear.h
@@ -8,7 +8,7 @@
 #include "../util/misc.h"
 
 namespace alfi::spline {
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	class LinearSpline {
 	public:
 		static Container<Number> compute_coeffs(const Container<Number>& X, const Container<Number>& Y) {

--- a/ALFI/ALFI/spline/quadratic.h
+++ b/ALFI/ALFI/spline/quadratic.h
@@ -11,7 +11,7 @@
 #include "../util/spline.h"
 
 namespace alfi::spline {
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	class QuadraticSpline {
 	public:
 		struct Types final {

--- a/ALFI/ALFI/spline/step.h
+++ b/ALFI/ALFI/spline/step.h
@@ -9,7 +9,7 @@
 #include "../util/misc.h"
 
 namespace alfi::spline {
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	class StepSpline {
 	public:
 		struct Types final {

--- a/ALFI/ALFI/util/arrays.h
+++ b/ALFI/ALFI/util/arrays.h
@@ -5,7 +5,7 @@
 #include "../config.h"
 
 namespace alfi::util::arrays {
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> add(const Container<Number>& container1, const Container<Number>& container2) {
 		if (container1.size() != container2.size()) {
 			std::cerr << "Error in function " << __FUNCTION__
@@ -22,7 +22,7 @@ namespace alfi::util::arrays {
 		return result;
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> sub(const Container<Number>& container1, const Container<Number>& container2) {
 		if (container1.size() != container2.size()) {
 			std::cerr << "Error in function " << __FUNCTION__
@@ -39,7 +39,7 @@ namespace alfi::util::arrays {
 		return result;
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> diff(const Container<Number>& container) {
 		if (container.empty()) {
 			return {};
@@ -51,7 +51,7 @@ namespace alfi::util::arrays {
 		return result;
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> mean(const Container<Number>& container1, const Container<Number>& container2) {
 		if (container1.size() != container2.size()) {
 			std::cerr << "Error in function " << __FUNCTION__

--- a/ALFI/ALFI/util/linalg.h
+++ b/ALFI/ALFI/util/linalg.h
@@ -28,7 +28,7 @@ namespace alfi::util::linalg {
 		@param epsilon a small threshold value to detect degeneracy (default is machine epsilon)
 		@return the solution vector or an empty container if the matrix is degenerate
 	 */
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> lup_solve(Container<Container<Number>>&& A, Container<Number>&& B, Number epsilon = std::numeric_limits<Number>::epsilon()) {
 		const auto n = B.size();
 		assert(n == A.size());
@@ -97,7 +97,7 @@ namespace alfi::util::linalg {
 		@param right the right-hand side vector of the system
 		@return the solution vector
 	 */
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> tridiag_solve_unstable(
 			const Container<Number>& lower,
 			Container<Number>&& diag,
@@ -144,7 +144,7 @@ namespace alfi::util::linalg {
 		@param right the right-hand side vector of the system
 		@return the solution vector
 	 */
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> tridiag_solve(
 			Container<Number>&& lower,
 			Container<Number>&& diag,

--- a/ALFI/ALFI/util/points.h
+++ b/ALFI/ALFI/util/points.h
@@ -3,7 +3,7 @@
 #include "../config.h"
 
 namespace alfi::points {
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	void lin_map(Container<Number>& points, Number a, Number b, Number c, Number d) {
 		const auto mid1 = (a + b) / 2;
 		const auto mid2 = (c + d) / 2;
@@ -13,14 +13,14 @@ namespace alfi::points {
 		}
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> lin_mapped(const Container<Number>& points, Number a, Number b, Number c, Number d) {
 		auto mapped_points = points;
 		lin_map<Number,Container>(mapped_points, a, b, c, d);
 		return mapped_points;
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	void stretch(Container<Number>& points, Number a, Number b) {
 		if (points.empty()) {
 			return;
@@ -34,7 +34,7 @@ namespace alfi::points {
 		points.back() = b;
 	}
 
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> stretched(const Container<Number>& points, Number a, Number b) {
 		auto stretched_points = points;
 		stretch<Number,Container>(stretched_points, a, b);

--- a/ALFI/ALFI/util/spline.h
+++ b/ALFI/ALFI/util/spline.h
@@ -6,7 +6,7 @@
 #include "../util/linalg.h"
 
 namespace alfi::util::spline {
-	template <typename Number = DefaultNumber, template <typename> class Container = DefaultContainer>
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 		Container<Number> simple_spline(const Container<Number>& X, const Container<Number>& Y, SizeT degree) {
 		if (X.size() != Y.size()) {
 			std::cerr << "Error in function " << __FUNCTION__

--- a/examples/interpolation/interpolation.cpp
+++ b/examples/interpolation/interpolation.cpp
@@ -30,11 +30,11 @@ class PlotWindow final : public QWidget {
 public:
 	static const inline std::vector<std::pair<QString,std::function<std::vector<double>(std::vector<double>,std::vector<double>,std::vector<double>)>>>
 	poly_types = {
-		{"Lagrange", [](const auto& X, const auto& Y, const auto& xx) { return alfi::poly::val<double,std::vector>(alfi::poly::lagrange(X, Y), xx); }},
+		{"Lagrange", [](const auto& X, const auto& Y, const auto& xx) { return alfi::poly::val(alfi::poly::lagrange(X, Y), xx); }},
 		{"Lagrange values", [](const auto& X, const auto& Y, const auto& xx) { return alfi::poly::lagrange_vals(X, Y, xx); }},
-		{"Improved Lagrange", [](const auto& X, const auto& Y, const auto& xx) { return alfi::poly::val<double,std::vector>(alfi::poly::imp_lagrange(X, Y), xx); }},
+		{"Improved Lagrange", [](const auto& X, const auto& Y, const auto& xx) { return alfi::poly::val(alfi::poly::imp_lagrange(X, Y), xx); }},
 		{"Improved Lagrange values", [](const auto& X, const auto& Y, const auto& xx) { return alfi::poly::imp_lagrange_vals(X, Y, xx); }},
-		{"Newton", [](const auto& X, const auto& Y, const auto& xx) { return alfi::poly::val<double,std::vector>(alfi::poly::newton(X, Y), xx); }},
+		{"Newton", [](const auto& X, const auto& Y, const auto& xx) { return alfi::poly::val(alfi::poly::newton(X, Y), xx); }},
 		{"Newton values", [](const auto& X, const auto& Y, const auto& xx) { return alfi::poly::newton_vals(X, Y, xx); }},
 	};
 	static const inline size_t poly_default_type_index = 0;
@@ -332,13 +332,13 @@ private:
 			if (barycentric_dist_type == 0) {
 				barycentric_dist_type = dist_type;
 			}
-			add_graph("Barycentric", xx, alfi::misc::barycentric<double,std::vector>(X, Y, xx, static_cast<alfi::dist::Type>(barycentric_dist_type)));
+			add_graph("Barycentric", xx, alfi::misc::barycentric(X, Y, xx, static_cast<alfi::dist::Type>(barycentric_dist_type)));
 		}
 		if (_step_spline_checkbox->isChecked()) {
 			add_graph("Step Spline", xx, alfi::spline::StepSpline(X, Y, step_spline_types[_step_spline_combo->currentIndex()].second)(xx));
 		}
 		if (_linear_spline_checkbox->isChecked()) {
-			add_graph("Linear Spline", xx, alfi::spline::LinearSpline<>(X, Y)(xx));
+			add_graph("Linear Spline", xx, alfi::spline::LinearSpline(X, Y)(xx));
 		}
 		if (_quadratic_spline_checkbox->isChecked()) {
 			add_graph("Quadratic Spline", xx, alfi::spline::QuadraticSpline<>(X, Y, quadratic_spline_types[_quadratic_spline_combo->currentIndex()].second)(xx));

--- a/tests/dist/test_dist.cpp
+++ b/tests/dist/test_dist.cpp
@@ -27,7 +27,7 @@ void test_distribution(const char*const name, const alfi::dist::Type type, doubl
 		mapping_intervals.for_each([&](const toml::array& interval) {
 			const auto c = interval[0].value<double>().value();
 			const auto d = interval[1].value<double>().value();
-			const auto mapped_expected = alfi::points::lin_mapped<double,std::vector>(expected, a, b, c, d);
+			const auto mapped_expected = alfi::points::lin_mapped(expected, a, b, c, d);
 			const auto mapped_generated = of_type(type, n, c, d, parameter);
 			expect_eq(mapped_generated, mapped_expected, epsilon);
 		});


### PR DESCRIPTION
### Types of changes
- Feature

Related: #7 #38

### Description
1. Added `, typename... Ts` to `DefaultContainer` to improve Template Argument Deduction for container types with more template arguments (like `std::vector`).
2. Changed `template <typename> class Container = DefaultContainer` to `template <typename, typename...> class Container = DefaultContainer` in templates for all functions and classes in library.
3. Removed some template argument specifications from `examples/interpolation/interpolation.cpp` and `tests/dist/test_dist.cpp` as they no longer needed due to improved Template Argument Deduction.