### PR TITLE
Removed `, typename...` from `DefaultContainer`

### DIFF
--- a/ALFI/ALFI/config.h
+++ b/ALFI/ALFI/config.h
@@ -16,8 +16,8 @@
 namespace alfi {
 	using DefaultNumber = ALFI_DEFAULT_NUMBER;
 
-	template <typename Number = DefaultNumber, typename... Ts>
-	using DefaultContainer = ALFI_DEFAULT_CONTAINER<Number, Ts...>;
+	template <typename Number = DefaultNumber>
+	using DefaultContainer = ALFI_DEFAULT_CONTAINER<Number>;
 
 	using SizeT = ALFI_SIZE_TYPE;
 


### PR DESCRIPTION
### Types of changes
- Refactoring, reformatting, cleanup

Related: #39

### Description
Changed
```c++
template <typename Number = DefaultNumber, typename ... Ts>
using DefaultContainer = ALFI_DEFAULT_CONTAINER<Number, Ts...>;
```
to
```c++
template <typename Number = DefaultNumber>
using DefaultContainer = ALFI_DEFAULT_CONTAINER<Number>;
```
, which reverts some changes from the previous pull request #39.

The reason is that the additional template arguments aren't used anywhere else in the library (they are defined, but don't have name &mdash; they are only used for better Template Argument Deduction).

New changes still allow users to define their own container types with different amount of template arguments.

For example:
```c++
#include <memory_resource>

template <typename Number>
using MyVector = std::vector<Number, std::pmr::polymorphic_allocator<Number>>;

#define ALFI_DEFAULT_CONTAINER MyVector
```