### PR TITLE
Added ability to set two arbitrary conditions for cubic splines

### DIFF
--- a/ALFI/ALFI/spline/cubic.h
+++ b/ALFI/ALFI/spline/cubic.h
@@ -354,14 +354,27 @@ namespace alfi::spline {
 				// only possible for Clamped and FixedSecond
 				if (i2 < i1) {
 					const auto i = i1; // ignoring i2
+					const auto* c
+						= std::holds_alternative<typename Conditions::Clamped>(custom->cond1)
+						? std::get_if<typename Conditions::Clamped>(&custom->cond1)
+						: std::get_if<typename Conditions::Clamped>(&custom->cond2);
+					const auto* fs
+						= std::holds_alternative<typename Conditions::FixedSecond>(custom->cond1)
+						? std::get_if<typename Conditions::FixedSecond>(&custom->cond1)
+						: std::get_if<typename Conditions::FixedSecond>(&custom->cond2);
+					assert(c && fs);
 					if (i > 0) {
+						coeffs[4*(i-1)] = (fs->d2f/2 - c->df/dX[i-1] + dY[i-1]/dX[i-1]/dX[i-1]) / dX[i-1];
+						coeffs[4*(i-1)+1] = 3*c->df/dX[i-1] - 3*dY[i-1]/dX[i-1]/dX[i-1] - fs->d2f;
+						coeffs[4*(i-1)+2] = 3*dY[i-1]/dX[i-1] + fs->d2f*dX[i-1]/2 - 2*c->df;
 						coeffs[4*(i-1)+3] = Y[i-1];
-
 						i1 = i - 1;
 					}
 					if (i < n - 1) {
+						coeffs[4*i] = (dY[i]/dX[i]/dX[i] - c->df/dX[i] - fs->d2f/2) / dX[i];
+						coeffs[4*i+1] = c->df;
+						coeffs[4*i+2] = fs->d2f/2;
 						coeffs[4*i+3] = Y[i];
-
 						i2 = i;
 					}
 				}

--- a/ALFI/ALFI/spline/cubic.h
+++ b/ALFI/ALFI/spline/cubic.h
@@ -273,52 +273,61 @@ namespace alfi::spline {
 					}
 				}
 
-				// check if same conditions on one point and return a somewhat reasonable approximation
+				// check if same conditions on one point and return a somewhat reasonable compromise solution
 				if (const auto c1 = std::get_if<typename Conditions::Clamped>(&custom->cond1),
 							c2 = std::get_if<typename Conditions::Clamped>(&custom->cond2);
 							c1 && c2) {
 					if (c1->point_idx == c2->point_idx) {
 						const auto df = (c1->df + c2->df) / 2;
-						return util::arrays::mean(
-							compute_coeffs(X, Y,
-								typename Types::Custom{typename Conditions::FixedThird{0, 0}, typename Conditions::Clamped{c1->point_idx, df}}),
-							compute_coeffs(X, Y,
-								typename Types::Custom{typename Conditions::Clamped{c1->point_idx, df}, typename Conditions::FixedThird{n - 2, 0}}));
+						if (c1->point_idx < n / 2) {
+							return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::Clamped{c1->point_idx, df}, typename Conditions::NotAKnot{n - 2}});
+						} else {
+							return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::NotAKnot{1}, typename Conditions::Clamped{c1->point_idx, df}});
+						}
 					}
 				} else if (const auto fs1 = std::get_if<typename Conditions::FixedSecond>(&custom->cond1),
 							fs2 = std::get_if<typename Conditions::FixedSecond>(&custom->cond2);
 							fs1 && fs2) {
 					if (fs1->point_idx == fs2->point_idx) {
 						const auto d2f = (fs1->d2f + fs2->d2f) / 2;
-						return util::arrays::mean(
-							compute_coeffs(X, Y,
-								typename Types::Custom{typename Conditions::FixedThird{0, 0}, typename Conditions::FixedSecond{fs1->point_idx, d2f}}),
-							compute_coeffs(X, Y,
-								typename Types::Custom{typename Conditions::FixedSecond{fs1->point_idx, d2f}, typename Conditions::FixedThird{n - 2, 0}}));
-					}
-				} else if (const auto nak1 = std::get_if<typename Conditions::NotAKnot>(&custom->cond1),
-							nak2 = std::get_if<typename Conditions::NotAKnot>(&custom->cond2);
-							nak1 && nak2) {
-					if (nak1->point_idx == nak2->point_idx) {
-						return util::arrays::mean(
-							compute_coeffs(X, Y,
-								typename Types::Custom{typename Conditions::FixedThird{0, 0}, typename Conditions::NotAKnot{nak1->point_idx}}),
-							compute_coeffs(X, Y,
-								typename Types::Custom{typename Conditions::NotAKnot{nak1->point_idx}, typename Conditions::FixedThird{n - 2, 0}}));
+						if (fs1->point_idx < n / 2) {
+							return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::FixedSecond{fs1->point_idx, d2f}, typename Conditions::NotAKnot{n - 2}});
+						} else {
+							return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::NotAKnot{1}, typename Conditions::FixedSecond{fs1->point_idx, d2f}});
+						}
 					}
 				} else if (const auto ft1 = std::get_if<typename Conditions::FixedThird>(&custom->cond1),
 							ft2 = std::get_if<typename Conditions::FixedThird>(&custom->cond2);
 							ft1 && ft2) {
 					if (ft1->segment_idx == ft2->segment_idx) {
-						const auto i = ft1->segment_idx;
-						const auto c = -dX[i] * (ft1->d3f + ft2->d3f) / 8;
-						coeffs[4*i] = -2*c / (3*dX[i]);
-						coeffs[4*i+1] = c;
-						coeffs[4*i+2] = dY[i]/dX[i] - dX[i] * c / 3;
-						coeffs[4*i+3] = Y[i];
-						i1 = i;
-						i2 = i + 1;
-						goto post_main_block;
+						if (n == 2) {
+							const auto i = ft1->segment_idx;
+							const auto c = -dX[i] * (ft1->d3f + ft2->d3f) / 8;
+							coeffs[4*i] = -2*c / (3*dX[i]);
+							coeffs[4*i+1] = c;
+							coeffs[4*i+2] = dY[i]/dX[i] - dX[i] * c / 3;
+							coeffs[4*i+3] = Y[i];
+							i1 = i;
+							i2 = i + 1;
+							goto post_main_block;
+						} else {
+							const auto d3f = (ft1->d3f + ft2->d3f) / 2;
+							if (ft1->segment_idx < n / 2) {
+								return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::FixedThird{ft1->segment_idx, d3f}, typename Conditions::NotAKnot{n - 2}});
+							} else {
+								return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::NotAKnot{1}, typename Conditions::FixedThird{ft1->segment_idx, d3f}});
+							}
+						}
+					}
+				} else if (const auto nak1 = std::get_if<typename Conditions::NotAKnot>(&custom->cond1),
+							nak2 = std::get_if<typename Conditions::NotAKnot>(&custom->cond2);
+							nak1 && nak2) {
+					if (nak1->point_idx == nak2->point_idx) {
+						if (nak1->point_idx < n / 2) {
+							return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::NotAKnot{nak1->point_idx}, typename Conditions::NotAKnot{n - 2}});
+						} else {
+							return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::NotAKnot{1}, typename Conditions::NotAKnot{nak1->point_idx}});
+						}
 					}
 				}
 

--- a/ALFI/ALFI/spline/cubic.h
+++ b/ALFI/ALFI/spline/cubic.h
@@ -116,7 +116,8 @@ namespace alfi::spline {
 								  typename Types::FixedThird,
 								  typename Types::NotAKnotStart,
 								  typename Types::NotAKnotEnd,
-								  typename Types::SemiNotAKnot>;
+								  typename Types::SemiNotAKnot,
+								  typename Types::Custom>;
 
 		static Container<Number> compute_coeffs(const Container<Number>& X, const Container<Number>& Y, Type type = typename Types::Default{}) {
 			if (X.size() != Y.size()) {
@@ -399,17 +400,17 @@ namespace alfi::spline {
 					[&](const typename Conditions::Clamped& c) {
 						diag[0] = 2*dX[i1];
 						upper[0] = dX[i1];
-						right[0] = 3 * (dY[i1]/dX[i1] - c.df_1);
+						right[0] = 3 * (dY[i1]/dX[i1] - c.df);
 					},
 					[&](const typename Conditions::FixedSecond& fs) {
 						diag[0] = 1;
 						upper[0] = 0;
-						right[0] = fs.d2f_1 / 2;
+						right[0] = fs.d2f / 2;
 					},
 					[&](const typename Conditions::FixedThird& ft) {
 						diag[0] = 1;
 						upper[0] = -1;
-						right[0] = -dX[i1] * ft.d3f_1 / 2;
+						right[0] = -dX[i1] * ft.d3f / 2;
 					},
 					[&](const typename Conditions::NotAKnot&) {
 						diag[0] = dX[i1] - dX[i1+1];
@@ -421,17 +422,17 @@ namespace alfi::spline {
 					[&](const typename Conditions::Clamped& c) {
 						lower[m-1] = dX[i1+m-2];
 						diag[m-1] = 2*dX[i1+m-2];
-						right[m-1] = 3 * (c.df_n - dY[i1+m-2]/dX[i1+m-2]);
+						right[m-1] = 3 * (c.df - dY[i1+m-2]/dX[i1+m-2]);
 					},
 					[&](const typename Conditions::FixedSecond& fs) {
 						lower[m-1] = 0;
 						diag[m-1] = 1;
-						right[m-1] = fs.d2f_n / 2;
+						right[m-1] = fs.d2f / 2;
 					},
 					[&](const typename Conditions::FixedThird& ft) {
 						lower[m-1] = -1;
 						diag[m-1] = 1;
-						right[m-1] = dX[i1+m-2] * ft.d3f_n / 2;
+						right[m-1] = dX[i1+m-2] * ft.d3f / 2;
 					},
 					[&](const typename Conditions::NotAKnot&) {
 						lower[m-1] = 2*dX[i1+m-2] + dX[i1+m-3];

--- a/ALFI/ALFI/spline/cubic.h
+++ b/ALFI/ALFI/spline/cubic.h
@@ -37,9 +37,9 @@ namespace alfi::spline {
 		};
 
 		using Condition = std::variant<typename Conditions::Clamped,
-								  typename Conditions::FixedSecond,
-								  typename Conditions::FixedThird,
-								  typename Conditions::NotAKnot>;
+									   typename Conditions::FixedSecond,
+									   typename Conditions::FixedThird,
+									   typename Conditions::NotAKnot>;
 
 		struct Types final {
 			/**

--- a/ALFI/ALFI/spline/cubic.h
+++ b/ALFI/ALFI/spline/cubic.h
@@ -408,7 +408,7 @@ namespace alfi::spline {
 					[&](const typename Conditions::NotAKnot&) {
 						diag[0] = dX[i1] - dX[i1+1];
 						upper[0] = 2*dX[i1] + dX[i1+1];
-						right[0] = dX[i1] / (dX[i1]+dX[i1+1]) * right[1];
+						right[0] = dX[i1] / (dX[i1]+dX[i1+1]) * 3 * (dY[i1+1]/dX[i1+1] - dY[i1]/dX[i1]);
 					},
 				}, custom->cond1);
 				std::visit(util::misc::overload{
@@ -430,7 +430,7 @@ namespace alfi::spline {
 					[&](const typename Conditions::NotAKnot&) {
 						lower[m-1] = 2*dX[i1+m-2] + dX[i1+m-3];
 						diag[m-1] = dX[i1+m-2] - dX[i1+m-3];
-						right[m-1] = dX[i1+m-2] / (dX[i1+m-2]+dX[i1+m-3]) * right[m-2];
+						right[m-1] = dX[i1+m-2] / (dX[i1+m-2]+dX[i1+m-3]) * 3 * (dY[i1+m-2]/dX[i1+m-2] - dY[i1+m-3]/dX[i1+m-3]);
 					},
 				}, custom->cond2);
 

--- a/ALFI/ALFI/spline/cubic.h
+++ b/ALFI/ALFI/spline/cubic.h
@@ -426,7 +426,7 @@ namespace alfi::spline {
 					[&](const typename Conditions::NotAKnot&) {
 						lower[m-1] = 2*dX[i1+m-2] + dX[i1+m-3];
 						diag[m-1] = dX[i1+m-2] - dX[i1+m-3];
-						right[m-1] = dX[i1+m-2] / (dX[i1+m-2]+dX[i1+m-3]) * right[n-2];
+						right[m-1] = dX[i1+m-2] / (dX[i1+m-2]+dX[i1+m-3]) * right[m-2];
 					},
 				}, custom->cond2);
 

--- a/ALFI/ALFI/spline/cubic.h
+++ b/ALFI/ALFI/spline/cubic.h
@@ -135,121 +135,233 @@ namespace alfi::spline {
 				return util::spline::simple_spline<Number,Container>(X, Y, 3);
 			}
 
+			if (std::holds_alternative<typename Types::Natural>(type)) {
+				return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::FixedSecond{0, 0}, typename Conditions::FixedSecond{n - 1, 0}});
+			} else if (std::holds_alternative<typename Types::NotAKnot>(type)) {
+				if (n == 2) {
+					return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::NotAKnot{0}, typename Conditions::NotAKnot{1}});
+				}
+				return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::NotAKnot{1}, typename Conditions::NotAKnot{n - 2}});
+			} else if (std::holds_alternative<typename Types::ParabolicEnds>(type)) {
+				return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::FixedThird{0, 0}, typename Conditions::FixedThird{n - 2, 0}});
+			} else if (const auto* c = std::get_if<typename Types::Clamped>(&type)) {
+				return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::Clamped{0, c->df_1}, typename Conditions::Clamped{n - 1, c->df_n}});
+			} else if (const auto* fs = std::get_if<typename Types::FixedSecond>(&type)) {
+				return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::FixedSecond{0, fs->d2f_1}, typename Conditions::FixedSecond{n - 1, fs->d2f_n}});
+			} else if (const auto* ft = std::get_if<typename Types::FixedThird>(&type)) {
+				return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::FixedThird{0, ft->d3f_1}, typename Conditions::FixedThird{n - 2, ft->d3f_n}});
+			} else if (std::holds_alternative<typename Types::NotAKnotStart>(type)) {
+				if (n == 2) {
+					return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::NotAKnot{0}, typename Conditions::NotAKnot{1}});
+				}
+				return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::NotAKnot{1}, typename Conditions::NotAKnot{2}});
+			} else if (std::holds_alternative<typename Types::NotAKnotEnd>(type)) {
+				if (n == 2) {
+					return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::NotAKnot{0}, typename Conditions::NotAKnot{1}});
+				}
+				return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::NotAKnot{n - 3}, typename Conditions::NotAKnot{n - 2}});
+			} else if (std::holds_alternative<typename Types::SemiNotAKnot>(type)) {
+				return util::arrays::mean(compute_coeffs(X, Y, typename Types::NotAKnotStart{}), compute_coeffs(X, Y, typename Types::NotAKnotEnd{}));
+			}
+
 			Container<Number> coeffs(4 * (n - 1));
 
+			SizeT i1 = 0, i2 = n - 1;
+
+			const auto dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
+
+			if (std::holds_alternative<typename Types::Periodic>(type)) {
+				if (n == 2) {
+					return util::spline::simple_spline<Number,Container>(X, Y, 3);
+				}
+
+				Container<Number> C(n);
+				if (n == 3) {
+					C[0] = 3 * (dY[0]/dX[0] - dY[1]/dX[1]) / (dX[0] + dX[1]);
+					C[1] = -C[0];
+					C[2] = C[0];
+				} else {
+					Container<Number> diag(n - 1), right(n - 1);
+					for (SizeT i = 0; i < n - 2; ++i) {
+						diag[i] = 2 * (dX[i] + dX[i+1]);
+						right[i] = 3 * (dY[i+1]/dX[i+1] - dY[i]/dX[i]);
+					}
+					diag[n-2] = 2 * (dX[n-2] + dX[0]);
+					right[n-2] = 3 * (dY[0]/dX[0] - dY[n-2]/dX[n-2]);
+
+					Container<Number> last_row(n - 2), last_col(n - 2);
+					last_row[0] = last_col[0] = dX[0];
+					for (SizeT i = 1; i < n - 3; ++i) {
+						last_row[i] = last_col[i] = 0;
+					}
+					last_row[n-3] = last_col[n-3] = dX[n-2];
+
+					for (SizeT i = 0; i < n - 3; ++i) {
+						const auto m1 = dX[i+1] / diag[i];
+						diag[i+1] -= m1 * dX[i+1];
+						last_col[i+1] -= m1 * last_col[i];
+						right[i+1] -= m1 * right[i];
+						const auto m2 = last_row[i] / diag[i];
+						last_row[i+1] -= m2 * dX[i+1];
+						diag[n-2] -= m2 * last_col[i];
+						right[n-2] -= m2 * right[i];
+					}
+					diag[n-2] -= last_row[n-3] / diag[n-3] * last_col[n-3];
+					right[n-2] -= last_row[n-3] / diag[n-3] * right[n-3];
+
+					C[n-1] = right[n-2] / diag[n-2];
+					C[n-2] = (right[n-3] - last_col[n-3] * C[n-1]) / diag[n-3];
+					for (SizeT i = n - 3; i >= 1; --i) {
+						C[i] = (right[i-1] - dX[i]*C[i+1] - last_col[i-1]*C[n-1]) / diag[i-1];
+					}
+					C[0] = C[n-1];
+				}
+
+				for (SizeT i = 0, index = 0; i < n - 1; ++i) {
+					coeffs[index++] = (C[i+1] - C[i]) / (3*dX[i]);
+					coeffs[index++] = C[i];
+					coeffs[index++] = dY[i]/dX[i] - dX[i] * ((2*C[i] + C[i+1]) / 3);
+					coeffs[index++] = Y[i];
+				}
+			} else if (auto* custom = std::get_if<typename Types::Custom>(&type)) {
+				if (std::holds_alternative<typename Conditions::NotAKnot>(custom->cond1)
+						&& std::holds_alternative<typename Conditions::NotAKnot>(custom->cond2)
+						&& n <= 4) {
+					return util::spline::simple_spline<Number,Container>(X, Y, 3);
+						}
+				if (const auto* c = std::get_if<typename Conditions::Clamped>(&custom->cond1)) {
+					const auto i = c->point_idx;
+
+				} else if (const auto* fs = std::get_if<typename Conditions::FixedSecond>(&custom->cond1)) {
+
+				} else if (const auto* ft = std::get_if<typename Conditions::FixedThird>(&custom->cond1)) {
+
+				} else if (const auto* nak = std::get_if<typename Conditions::NotAKnot>(&custom->cond1)) {
+
+				} else {
+					std::cerr << "Error in function " << __FUNCTION__ << ": Unknown first condition of 'Custom' type. This should not have happened."
+							  << " Please report this to the developers. Returning an empty array..." << std::endl;
+					return {};
+				}
+				if (const auto* c = std::get_if<typename Conditions::Clamped>(&custom->cond2)) {
+
+				} else if (const auto* fs = std::get_if<typename Conditions::FixedSecond>(&custom->cond2)) {
+
+				} else if (const auto* ft = std::get_if<typename Conditions::FixedThird>(&custom->cond2)) {
+
+				} else if (const auto* nak = std::get_if<typename Conditions::NotAKnot>(&custom->cond2)) {
+
+				} else {
+					std::cerr << "Error in function " << __FUNCTION__ << ": Unknown second condition of 'Custom' type. This should not have happened."
+							  << " Please report this to the developers. Returning an empty array..." << std::endl;
+					return {};
+				}
+				if (auto c1 = std::get_if<typename Conditions::Clamped>(&custom->cond1),
+						c2 = std::get_if<typename Conditions::Clamped>(&custom->cond2);
+						c1 && c2) {
+					if (c2->point_idx < c1->point_idx) {
+						std::swap(custom->cond1, custom->cond2);
+					}
+				}
+				if (auto fs1 = std::get_if<typename Conditions::FixedSecond>(&custom->cond1),
+						fs2 = std::get_if<typename Conditions::FixedSecond>(&custom->cond2);
+						fs1 && fs2) {
+					if (fs2->point_idx < fs1->point_idx) {
+						std::swap(custom->cond1, custom->cond2);
+					}
+				}
+				if (auto ft1 = std::get_if<typename Conditions::FixedThird>(&custom->cond1),
+						ft2 = std::get_if<typename Conditions::FixedThird>(&custom->cond2);
+						ft1 && ft2) {
+					if (ft2->segment_idx < ft1->segment_idx) {
+						std::swap(custom->cond1, custom->cond2);
+					}
+				}
+				if (auto n1 = std::get_if<typename Conditions::NotAKnot>(&custom->cond1),
+						n2 = std::get_if<typename Conditions::NotAKnot>(&custom->cond2);
+						n1 && n2) {
+					if (n2->point_idx < n1->point_idx) {
+						std::swap(custom->cond1, custom->cond2);
+					}
+				}
+
+				if (std::holds_alternative<typename Conditions::FixedThird>(custom->cond1)
+					&& std::holds_alternative<typename Conditions::FixedThird>(custom->cond2)
+					&& n == 2) {
+					// проверить индексы и приравнять третьи производные их среднему арифметическому
+				}
+
+				Container<Number> lower(n), diag(n), upper(n), right(n);
+				for (SizeT i = 1; i < n - 1; ++i) {
+					lower[i] = dX[i-1];
+					diag[i] = 2 * (dX[i-1] + dX[i]);
+					upper[i] = dX[i];
+					right[i] = 3 * (dY[i]/dX[i] - dY[i-1]/dX[i-1]);
+				}
+				lower[0] = NAN;
+				upper[n-1] = NAN;
+
+				// уникальные условия
+
+				const auto C = util::linalg::tridiag_solve<Number,Container>(
+					std::move(lower), std::move(diag), std::move(upper), std::move(right));
+
+				for (SizeT i = 0, index = 0; i < n - 1; ++i) {
+					coeffs[index++] = (C[i+1] - C[i]) / (3*dX[i]);
+					coeffs[index++] = C[i];
+					coeffs[index++] = dY[i]/dX[i] - dX[i] * ((2*C[i] + C[i+1]) / 3);
+					coeffs[index++] = Y[i];
+				}
+
+				// здесь делаю дополнительные правки
+
+			} else {
+				std::cerr << "Error in function " << __FUNCTION__ << ": Unknown type. This should not have happened."
+						  << " Please report this to the developers. Returning an empty array..." << std::endl;
+				return {};
+			}
+
+			for (SizeT iter = 0; iter < i1; ++iter) {
+				const auto i = i1 - 1 - iter;
+				coeffs[4*i] = (coeffs[4*(i+1)+1] - coeffs[4*(i+1)+2]/dX[i] + dY[i]/pow(dX[i], 2)) / dX[i];
+				coeffs[4*i+1] = coeffs[4*(i+1)+1] - 3 * coeffs[4*i] * dX[i];
+				coeffs[4*i+2] = dY[i]/dX[i] - coeffs[4*i]*pow(dX[i], 2) - coeffs[4*i+1]*dX[i];
+				coeffs[4*i+3] = Y[i];
+			}
+
+			for (SizeT i = i2 + 1; i < n - 1; ++i) {
+				coeffs[4*i+3] = Y[i];
+				coeffs[4*i+2] = 3 * coeffs[4*(i-1)] * pow(dX[i-1], 2) + 2 * coeffs[4*(i-1)+1] * dX[i-1] + coeffs[4*(i-1)+2];
+				coeffs[4*i+1] = 3 * coeffs[4*(i-1)] * dX[i-1] + coeffs[4*(i-1)+1];
+				coeffs[4*i] = (dY[i]/dX[i] - coeffs[4*i+1] * dX[i] - coeffs[4*i+2]) / pow(dX[i], 2);
+			}
+
 			std::visit(util::misc::overload{
-				[&](const typename Types::Natural&) {
-					coeffs = compute_coeffs(X, Y, typename Types::FixedSecond{0, 0});
-				},
 				[&](const typename Types::NotAKnot&) {
-					if (n <= 4) {
-						coeffs = util::spline::simple_spline<Number,Container>(X, Y, 3);
-						return;
-					}
-					const auto dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
-					Container<Number> lower(n), diag(n), upper(n), right(n);
-					for (SizeT i = 1; i < n - 1; ++i) {
-						lower[i] = dX[i-1];
-						diag[i] = 2 * (dX[i-1] + dX[i]);
-						upper[i] = dX[i];
-						right[i] = 3 * (dY[i]/dX[i] - dY[i-1]/dX[i-1]);
-					}
-					lower[0] = NAN;
-					diag[0] = dX[0] - dX[1];
-					upper[0] = 2*dX[0] + dX[1];
-					right[0] = dX[0] / (dX[0]+dX[1]) * right[1];
-					lower[n-1] = 2*dX[n-2] + dX[n-3];
-					diag[n-1] = dX[n-2] - dX[n-3];
-					upper[n-1] = NAN;
-					right[n-1] = dX[n-2] / (dX[n-2]+dX[n-3]) * right[n-2];
-					const auto C = util::linalg::tridiag_solve<Number,Container>(
-						std::move(lower), std::move(diag), std::move(upper), std::move(right));
+					// diag[0] = dX[0] - dX[1];
+					// upper[0] = 2*dX[0] + dX[1];
+					// right[0] = dX[0] / (dX[0]+dX[1]) * right[1];
+					// lower[n-1] = 2*dX[n-2] + dX[n-3];
+					// diag[n-1] = dX[n-2] - dX[n-3];
+					// right[n-1] = dX[n-2] / (dX[n-2]+dX[n-3]) * right[n-2];
+					// const auto C = util::linalg::tridiag_solve<Number,Container>(
+					// 	std::move(lower), std::move(diag), std::move(upper), std::move(right));
 					for (SizeT i = 0, index = 0; i < n - 1; ++i) {
 						coeffs[index++] = (C[i+1] - C[i]) / (3*dX[i]);
 						coeffs[index++] = C[i];
 						coeffs[index++] = dY[i]/dX[i] - dX[i] * ((2*C[i] + C[i+1]) / 3);
 						coeffs[index++] = Y[i];
 					}
-				},
-				[&](const typename Types::Periodic&) {
-					if (n <= 2) {
-						coeffs = util::spline::simple_spline<Number,Container>(X, Y, 3);
-						return;
-					}
-
-					const auto dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
-
-					Container<Number> C(n);
-					if (n == 3) {
-						C[0] = 3 * (dY[0]/dX[0] - dY[1]/dX[1]) / (dX[0] + dX[1]);
-						C[1] = -C[0];
-						C[2] = C[0];
-					} else {
-						Container<Number> diag(n - 1), right(n - 1);
-						for (SizeT i = 0; i < n - 2; ++i) {
-							diag[i] = 2 * (dX[i] + dX[i+1]);
-							right[i] = 3 * (dY[i+1]/dX[i+1] - dY[i]/dX[i]);
-						}
-						diag[n-2] = 2 * (dX[n-2] + dX[0]);
-						right[n-2] = 3 * (dY[0]/dX[0] - dY[n-2]/dX[n-2]);
-
-						Container<Number> last_row(n - 2), last_col(n - 2);
-						last_row[0] = last_col[0] = dX[0];
-						for (SizeT i = 1; i < n - 3; ++i) {
-							last_row[i] = last_col[i] = 0;
-						}
-						last_row[n-3] = last_col[n-3] = dX[n-2];
-
-						for (SizeT i = 0; i < n - 3; ++i) {
-							const auto m1 = dX[i+1] / diag[i];
-							diag[i+1] -= m1 * dX[i+1];
-							last_col[i+1] -= m1 * last_col[i];
-							right[i+1] -= m1 * right[i];
-							const auto m2 = last_row[i] / diag[i];
-							last_row[i+1] -= m2 * dX[i+1];
-							diag[n-2] -= m2 * last_col[i];
-							right[n-2] -= m2 * right[i];
-						}
-						diag[n-2] -= last_row[n-3] / diag[n-3] * last_col[n-3];
-						right[n-2] -= last_row[n-3] / diag[n-3] * right[n-3];
-
-						C[n-1] = right[n-2] / diag[n-2];
-						C[n-2] = (right[n-3] - last_col[n-3] * C[n-1]) / diag[n-3];
-						for (SizeT i = n - 3; i >= 1; --i) {
-							C[i] = (right[i-1] - dX[i]*C[i+1] - last_col[i-1]*C[n-1]) / diag[i-1];
-						}
-						C[0] = C[n-1];
-					}
-
-					for (SizeT i = 0, index = 0; i < n - 1; ++i) {
-						coeffs[index++] = (C[i+1] - C[i]) / (3*dX[i]);
-						coeffs[index++] = C[i];
-						coeffs[index++] = dY[i]/dX[i] - dX[i] * ((2*C[i] + C[i+1]) / 3);
-						coeffs[index++] = Y[i];
-					}
-				},
-				[&](const typename Types::ParabolicEnds&) {
-					coeffs = compute_coeffs(X, Y, typename Types::FixedThird{0, 0});
 				},
 				[&](const typename Types::Clamped& c) {
-					const auto dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
-					Container<Number> lower(n), diag(n), upper(n), right(n);
-					for (SizeT i = 1; i < n - 1; ++i) {
-						lower[i] = dX[i-1];
-						diag[i] = 2 * (dX[i-1] + dX[i]);
-						upper[i] = dX[i];
-						right[i] = 3 * (dY[i]/dX[i] - dY[i-1]/dX[i-1]);
-					}
-					lower[0] = NAN;
-					diag[0] = 2*dX[0];
-					upper[0] = dX[0];
-					right[0] = 3 * (dY[0]/dX[0] - c.df_1);
-					lower[n-1] = dX[n-2];
-					diag[n-1] = 2*dX[n-2];
-					upper[n-1] = NAN;
-					right[n-1] = 3 * (c.df_n - dY[n-2]/dX[n-2]);
-					const auto C = util::linalg::tridiag_solve<Number,Container>(
-						std::move(lower), std::move(diag), std::move(upper), std::move(right));
+					// diag[0] = 2*dX[0];
+					// upper[0] = dX[0];
+					// right[0] = 3 * (dY[0]/dX[0] - c.df_1);
+					// lower[n-1] = dX[n-2];
+					// diag[n-1] = 2*dX[n-2];
+					// right[n-1] = 3 * (c.df_n - dY[n-2]/dX[n-2]);
+					// const auto C = util::linalg::tridiag_solve<Number,Container>(
+					// 	std::move(lower), std::move(diag), std::move(upper), std::move(right));
 					for (SizeT i = 0, index = 0; i < n - 1; ++i) {
 						coeffs[index++] = (C[i+1] - C[i]) / (3*dX[i]);
 						coeffs[index++] = C[i];
@@ -258,24 +370,14 @@ namespace alfi::spline {
 					}
 				},
 				[&](const typename Types::FixedSecond& s) {
-					const auto dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
-					Container<Number> lower(n), diag(n), upper(n), right(n);
-					for (SizeT i = 1; i < n - 1; ++i) {
-						lower[i] = dX[i-1];
-						diag[i] = 2 * (dX[i-1] + dX[i]);
-						upper[i] = dX[i];
-						right[i] = 3 * (dY[i]/dX[i] - dY[i-1]/dX[i-1]);
-					}
-					lower[0] = NAN;
-					diag[0] = 1;
-					upper[0] = 0;
-					right[0] = s.d2f_1 / 2;
-					lower[n-1] = 0;
-					diag[n-1] = 1;
-					upper[n-1] = NAN;
-					right[n-1] = s.d2f_n / 2;
-					const auto C = util::linalg::tridiag_solve<Number,Container>(
-						std::move(lower), std::move(diag), std::move(upper), std::move(right));
+					// diag[0] = 1;
+					// upper[0] = 0;
+					// right[0] = s.d2f_1 / 2;
+					// lower[n-1] = 0;
+					// diag[n-1] = 1;
+					// right[n-1] = s.d2f_n / 2;
+					// const auto C = util::linalg::tridiag_solve<Number,Container>(
+					// 	std::move(lower), std::move(diag), std::move(upper), std::move(right));
 					for (SizeT i = 0, index = 0; i < n - 1; ++i) {
 						coeffs[index++] = (C[i+1] - C[i]) / (3*dX[i]);
 						coeffs[index++] = C[i];
@@ -284,29 +386,19 @@ namespace alfi::spline {
 					}
 				},
 				[&](const typename Types::FixedThird& t) {
-					const auto dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
 					Container<Number> C(n);
 					if (n == 2) {
 						C[0] = -dX[0] * (t.d3f_1 + t.d3f_n) / 8;
 						C[1] = -C[0];
 					} else {
-						Container<Number> lower(n), diag(n), upper(n), right(n);
-						for (SizeT i = 1; i < n - 1; ++i) {
-							lower[i] = dX[i-1];
-							diag[i] = 2 * (dX[i-1] + dX[i]);
-							upper[i] = dX[i];
-							right[i] = 3 * (dY[i]/dX[i] - dY[i-1]/dX[i-1]);
-						}
-						lower[0] = NAN;
-						diag[0] = 1;
-						upper[0] = -1;
-						right[0] = -dX[0] * t.d3f_1 / 2;
-						lower[n-1] = -1;
-						diag[n-1] = 1;
-						upper[n-1] = NAN;
-						right[n-1] = dX[n-2] * t.d3f_n / 2;
-						C = util::linalg::tridiag_solve<Number,Container>(
-							std::move(lower), std::move(diag), std::move(upper), std::move(right));
+						// diag[0] = 1;
+						// upper[0] = -1;
+						// right[0] = -dX[0] * t.d3f_1 / 2;
+						// lower[n-1] = -1;
+						// diag[n-1] = 1;
+						// right[n-1] = dX[n-2] * t.d3f_n / 2;
+						// C = util::linalg::tridiag_solve<Number,Container>(
+						// 	std::move(lower), std::move(diag), std::move(upper), std::move(right));
 					}
 					Container<Number> D(n - 1);
 					for (SizeT i = 1; i < D.size() - 1; ++i) {
@@ -324,105 +416,7 @@ namespace alfi::spline {
 						coeffs[index++] = dY[i]/dX[i] - dX[i] * ((2*C[i] + C[i+1]) / 3);
 						coeffs[index++] = Y[i];
 					}
-				},
-				[&](const typename Types::NotAKnotStart&) {
-					if (n <= 4) {
-						coeffs = util::spline::simple_spline<Number,Container>(X, Y, 3);
-						return;
-					}
-
-					const auto dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
-
-					{ // first four points
-						const auto h1 = dX[0], h2 = dX[1];
-						const auto h12 = X[2]-X[0], h13 = X[3]-X[0];
-						const auto d1 = Y[1]-Y[0], d12 = Y[2]-Y[0], d13 = Y[3]-Y[0];
-
-						const auto abc = util::linalg::lup_solve<Number,Container>(
-							{{std::pow(h1, 3), std::pow(h1, 2), h1},
-								{std::pow(h12, 3), std::pow(h12, 2), h12},
-								{std::pow(h13, 3), std::pow(h13, 2), h13}},
-							{d1, d12, d13});
-						if (abc.empty()) {
-							std::cerr << "Error in function " << FUNCTION << ": Could not compute. Returning an empty array..." << std::endl;
-							coeffs = {};
-							return;
-						}
-
-						const auto a = abc[0], b = abc[1], c = abc[2];
-
-						coeffs[0] = a; // a1
-						coeffs[1] = b; // b1
-						coeffs[2] = c; // c1
-						coeffs[3] = Y[0]; // d1
-						coeffs[4] = a; // a2
-						coeffs[5] = 3 * a * h1 + b; // b2
-						coeffs[6] = 3 * a * std::pow(h1, 2) + 2 * b * h1 + c; // c2
-						coeffs[7] = Y[1]; // d2
-						coeffs[8] = a; // a3
-						coeffs[9] = 3 * a * h2 + coeffs[5]; // b3
-						coeffs[10] = 3 * a * std::pow(h2, 2) + 2 * coeffs[5] * h2 + coeffs[6]; // c3
-						coeffs[11] = Y[2]; // d3
-					}
-
-					for (SizeT i = 3; i < n - 1; ++i) {
-						coeffs[4*i+3] = Y[i];
-						coeffs[4*i+2] = 3 * coeffs[4*(i-1)] * pow(dX[i-1], 2) + 2 * coeffs[4*(i-1)+1] * dX[i-1] + coeffs[4*(i-1)+2];
-						coeffs[4*i+1] = 3 * coeffs[4*(i-1)] * dX[i-1] + coeffs[4*(i-1)+1];
-						coeffs[4*i] = (dY[i]/dX[i] - coeffs[4*i+1] * dX[i] - coeffs[4*i+2]) / pow(dX[i], 2);
-					}
-				},
-				[&](const typename Types::NotAKnotEnd&) {
-					if (n <= 4) {
-						coeffs = util::spline::simple_spline<Number,Container>(X, Y, 3);
-						return;
-					}
-
-					const auto dX = util::arrays::diff(X), dY = util::arrays::diff(Y);
-
-					{ // last four points
-						const auto h1 = dX[n-4], h2 = dX[n-3];
-						const auto h12 = X[n-2]-X[n-4], h13 = X[n-1]-X[n-4];
-						const auto d1 = dY[n-4], d12 = Y[n-2] - Y[n-4], d13 = Y[n-1] - Y[n-4];
-
-						const auto abc = util::linalg::lup_solve<Number,Container>(
-							{{std::pow(h1, 3), std::pow(h1, 2), h1},
-								{std::pow(h12, 3), std::pow(h12, 2), h12},
-								{std::pow(h13, 3), std::pow(h13, 2), h13}},
-							{d1, d12, d13});
-						if (abc.empty()) {
-							std::cerr << "Error in function " << FUNCTION << ": Could not compute. Returning an empty array..." << std::endl;
-							coeffs = {};
-							return;
-						}
-
-						const auto a = abc[0], b = abc[1], c = abc[2];
-
-						coeffs[4*(n-4)] = a; // an-3
-						coeffs[4*(n-4)+1] = b; // bn-3
-						coeffs[4*(n-4)+2] = c; // cn-3
-						coeffs[4*(n-4)+3] = Y[n-4]; // dn-3
-						coeffs[4*(n-3)] = a; // an-2
-						coeffs[4*(n-3)+1] = 3 * a * h1 + b; // bn-2
-						coeffs[4*(n-3)+2] = 3 * a * std::pow(h1, 2) + 2 * b * h1 + c; // cn-2
-						coeffs[4*(n-3)+3] = Y[n-3]; // dn-2
-						coeffs[4*(n-2)] = a; // an-1
-						coeffs[4*(n-2)+1] = 3 * a * h2 + coeffs[4*(n-3)+1]; // bn-1
-						coeffs[4*(n-2)+2] = 3 * a * std::pow(h2, 2) + 2 * coeffs[4*(n-3)+1] * h2 + coeffs[4*(n-3)+2]; // cn-1
-						coeffs[4*(n-2)+3] = Y[n-2]; // dn-1
-					}
-
-					for (SizeT iter = 0; iter <= n - 5; ++iter) {
-						const auto i = n - 5 - iter;
-						coeffs[4*i] = (coeffs[4*(i+1)+1] - coeffs[4*(i+1)+2]/dX[i] + dY[i]/pow(dX[i], 2)) / dX[i];
-						coeffs[4*i+1] = coeffs[4*(i+1)+1] - 3 * coeffs[4*i] * dX[i];
-						coeffs[4*i+2] = dY[i]/dX[i] - coeffs[4*i]*pow(dX[i], 2) - coeffs[4*i+1]*dX[i];
-						coeffs[4*i+3] = Y[i];
-					}
-				},
-				[&](const typename Types::SemiNotAKnot&) {
-					coeffs = util::arrays::mean(compute_coeffs(X, Y, typename Types::NotAKnotStart{}), compute_coeffs(X, Y, typename Types::NotAKnotEnd{}));
-				},
+				}
 			}, type);
 
 			return coeffs;

--- a/ALFI/ALFI/spline/cubic.h
+++ b/ALFI/ALFI/spline/cubic.h
@@ -14,6 +14,33 @@ namespace alfi::spline {
 	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	class CubicSpline {
 	public:
+		struct Conditions final {
+			struct Clamped final {
+				Clamped(SizeT point_idx, Number df) : point_idx(std::move(point_idx)), df(std::move(df)) {}
+				SizeT point_idx;
+				Number df;
+			};
+			struct FixedSecond final {
+				FixedSecond(SizeT point_idx, Number d2f) : point_idx(std::move(point_idx)), d2f(std::move(d2f)) {}
+				SizeT point_idx;
+				Number d2f;
+			};
+			struct FixedThird final {
+				FixedThird(SizeT segment_idx, Number d3f) : segment_idx(std::move(segment_idx)), d3f(std::move(d3f)) {}
+				SizeT segment_idx;
+				Number d3f;
+			};
+			struct NotAKnot final {
+				explicit NotAKnot(SizeT point_idx) : point_idx(std::move(point_idx)) {}
+				SizeT point_idx;
+			};
+		};
+
+		using Condition = std::variant<typename Conditions::Clamped,
+								  typename Conditions::FixedSecond,
+								  typename Conditions::FixedThird,
+								  typename Conditions::NotAKnot>;
+
 		struct Types final {
 			/**
 				Second derivatives at the end points are equal to zero.\n
@@ -73,6 +100,10 @@ namespace alfi::spline {
 				The arithmetic mean of NotAKnotStart and NotAKnotEnd.
 			 */
 			struct SemiNotAKnot final {};
+			struct Custom final {
+				Custom(Condition condition1, Condition condition2) : cond1(std::move(condition1)), cond2(std::move(condition2)) {}
+				Condition cond1, cond2;
+			};
 			using Default = Natural;
 		};
 

--- a/ALFI/ALFI/spline/cubic.h
+++ b/ALFI/ALFI/spline/cubic.h
@@ -142,6 +142,9 @@ namespace alfi::spline {
 				}
 				return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::NotAKnot{1}, typename Conditions::NotAKnot{n - 2}});
 			} else if (std::holds_alternative<typename Types::ParabolicEnds>(type)) {
+				if (n <= 3) {
+					return util::spline::simple_spline<Number,Container>(X, Y, 3);
+				}
 				return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::FixedThird{0, 0}, typename Conditions::FixedThird{n - 2, 0}});
 			} else if (const auto* c = std::get_if<typename Types::Clamped>(&type)) {
 				return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::Clamped{0, c->df_1}, typename Conditions::Clamped{n - 1, c->df_n}});
@@ -160,6 +163,9 @@ namespace alfi::spline {
 				}
 				return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::NotAKnot{n - 3}, typename Conditions::NotAKnot{n - 2}});
 			} else if (std::holds_alternative<typename Types::SemiNotAKnot>(type)) {
+				if (n <= 4) {
+					return util::spline::simple_spline<Number,Container>(X, Y, 3);
+				}
 				return util::arrays::mean(compute_coeffs(X, Y, typename Types::NotAKnotStart{}), compute_coeffs(X, Y, typename Types::NotAKnotEnd{}));
 			}
 

--- a/ALFI/ALFI/spline/cubic.h
+++ b/ALFI/ALFI/spline/cubic.h
@@ -137,8 +137,8 @@ namespace alfi::spline {
 			if (std::holds_alternative<typename Types::Natural>(type)) {
 				return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::FixedSecond{0, 0}, typename Conditions::FixedSecond{n - 1, 0}});
 			} else if (std::holds_alternative<typename Types::NotAKnot>(type)) {
-				if (n == 2) {
-					return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::NotAKnot{0}, typename Conditions::NotAKnot{1}});
+				if (n <= 4) {
+					return util::spline::simple_spline<Number,Container>(X, Y, 3);
 				}
 				return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::NotAKnot{1}, typename Conditions::NotAKnot{n - 2}});
 			} else if (std::holds_alternative<typename Types::ParabolicEnds>(type)) {
@@ -150,13 +150,13 @@ namespace alfi::spline {
 			} else if (const auto* ft = std::get_if<typename Types::FixedThird>(&type)) {
 				return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::FixedThird{0, ft->d3f_1}, typename Conditions::FixedThird{n - 2, ft->d3f_n}});
 			} else if (std::holds_alternative<typename Types::NotAKnotStart>(type)) {
-				if (n == 2) {
-					return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::NotAKnot{0}, typename Conditions::NotAKnot{1}});
+				if (n <= 4) {
+					return util::spline::simple_spline<Number,Container>(X, Y, 3);
 				}
 				return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::NotAKnot{1}, typename Conditions::NotAKnot{2}});
 			} else if (std::holds_alternative<typename Types::NotAKnotEnd>(type)) {
-				if (n == 2) {
-					return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::NotAKnot{0}, typename Conditions::NotAKnot{1}});
+				if (n <= 4) {
+					return util::spline::simple_spline<Number,Container>(X, Y, 3);
 				}
 				return compute_coeffs(X, Y, typename Types::Custom{typename Conditions::NotAKnot{n - 3}, typename Conditions::NotAKnot{n - 2}});
 			} else if (std::holds_alternative<typename Types::SemiNotAKnot>(type)) {
@@ -226,7 +226,7 @@ namespace alfi::spline {
 				// special case
 				if (std::holds_alternative<typename Conditions::NotAKnot>(custom->cond1)
 						&& std::holds_alternative<typename Conditions::NotAKnot>(custom->cond2)
-						&& n <= 4) {
+						&& n <= 3) {
 					return util::spline::simple_spline<Number,Container>(X, Y, 3);
 				}
 

--- a/ALFI/ALFI/spline/cubic.h
+++ b/ALFI/ALFI/spline/cubic.h
@@ -119,10 +119,8 @@ namespace alfi::spline {
 								  typename Types::SemiNotAKnot>;
 
 		static Container<Number> compute_coeffs(const Container<Number>& X, const Container<Number>& Y, Type type = typename Types::Default{}) {
-			constexpr auto FUNCTION = __FUNCTION__;
-
 			if (X.size() != Y.size()) {
-				std::cerr << "Error in function " << FUNCTION
+				std::cerr << "Error in function " << __FUNCTION__
 						  << ": Vectors X (of size " << X.size()
 						  << ") and Y (of size " << Y.size()
 						  << ") are not the same size. Returning an empty array..." << std::endl;
@@ -305,9 +303,9 @@ namespace alfi::spline {
 					[&](const typename Conditions::NotAKnot& nak) { i2 = nak.point_idx; },
 				}, custom->cond2);
 
-				// special case
+				// special case: both conditions on one point
 				if (i2 < i1) {
-
+					
 				}
 
 				// number of points in the "subspline"
@@ -410,17 +408,17 @@ namespace alfi::spline {
 		post_main_block:
 			for (SizeT iter = 0; iter < i1; ++iter) {
 				const auto i = i1 - 1 - iter;
-				coeffs[4*i] = (coeffs[4*(i+1)+1] - coeffs[4*(i+1)+2]/dX[i] + dY[i]/pow(dX[i], 2)) / dX[i];
+				coeffs[4*i] = (coeffs[4*(i+1)+1] - coeffs[4*(i+1)+2]/dX[i] + dY[i]/dX[i]/dX[i]) / dX[i];
 				coeffs[4*i+1] = coeffs[4*(i+1)+1] - 3 * coeffs[4*i] * dX[i];
-				coeffs[4*i+2] = dY[i]/dX[i] - coeffs[4*i]*pow(dX[i], 2) - coeffs[4*i+1]*dX[i];
+				coeffs[4*i+2] = dY[i]/dX[i] - coeffs[4*i]*dX[i]*dX[i] - coeffs[4*i+1]*dX[i];
 				coeffs[4*i+3] = Y[i];
 			}
 
 			for (SizeT i = i2 + 1; i < n - 1; ++i) {
 				coeffs[4*i+3] = Y[i];
-				coeffs[4*i+2] = 3 * coeffs[4*(i-1)] * pow(dX[i-1], 2) + 2 * coeffs[4*(i-1)+1] * dX[i-1] + coeffs[4*(i-1)+2];
-				coeffs[4*i+1] = 3 * coeffs[4*(i-1)] * dX[i-1] + coeffs[4*(i-1)+1];
-				coeffs[4*i] = (dY[i]/dX[i] - coeffs[4*i+1] * dX[i] - coeffs[4*i+2]) / pow(dX[i], 2);
+				coeffs[4*i+2] = 3 * coeffs[4*(i-1)]*dX[i-1]*dX[i-1] + 2 * coeffs[4*(i-1)+1]*dX[i-1] + coeffs[4*(i-1)+2];
+				coeffs[4*i+1] = 3 * coeffs[4*(i-1)]*dX[i-1] + coeffs[4*(i-1)+1];
+				coeffs[4*i] = (dY[i]/dX[i]/dX[i] - coeffs[4*i+1] - coeffs[4*i+2]/dX[i]) / dX[i];
 			}
 
 			return coeffs;

--- a/ALFI/ALFI/spline/cubic.h
+++ b/ALFI/ALFI/spline/cubic.h
@@ -272,6 +272,7 @@ namespace alfi::spline {
 						return {};
 					}
 				}
+
 				// check if same conditions on one point and return a somewhat reasonable approximation
 				if (const auto c1 = std::get_if<typename Conditions::Clamped>(&custom->cond1),
 							c2 = std::get_if<typename Conditions::Clamped>(&custom->cond2);

--- a/tests/spline/test_cubic.cpp
+++ b/tests/spline/test_cubic.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <ALFI/dist.h>
 #include <ALFI/spline/cubic.h>
 
 TEST(CubicSplineTest, General) {
@@ -10,6 +11,96 @@ TEST(CubicSplineTest, General) {
 		EXPECT_EQ(spline(X[i]), Y[i]);
 		EXPECT_EQ(spline(X[i+1]), Y[i+1]);
 	}
+}
+
+TEST(CubicSplineTest, BasicConditions) {
+	const size_t n = 10;
+	const double a = -1, b = 1;
+	const auto X = alfi::dist::uniform(n, a, b);
+	const auto dX = alfi::util::arrays::diff(X);
+	const auto Y = alfi::dist::circle_proj(n, a, b);
+	auto spline = alfi::spline::CubicSpline<>(X, Y, alfi::spline::CubicSpline<>::Types::Natural{});
+	EXPECT_NEAR(0, 2*spline.coeffs()[1], 1e-17);
+	EXPECT_NEAR(0, 2*spline.coeffs()[4*8+1] + 6*spline.coeffs()[4*8]*dX[8], 1e-15);
+	spline.construct(X, Y, alfi::spline::CubicSpline<>::Types::NotAKnot{});
+	EXPECT_NEAR(spline.coeffs()[0], spline.coeffs()[4], 1e-15);
+	EXPECT_NEAR(spline.coeffs()[4*7], spline.coeffs()[4*8], 1e-14);
+	spline.construct(X, Y, alfi::spline::CubicSpline<>::Types::Periodic{});
+	EXPECT_NEAR(spline.coeffs()[2], spline.coeffs()[4*8+2] + 2*spline.coeffs()[4*8+1]*dX[8] + 3*spline.coeffs()[4*8]*dX[8]*dX[8], 1e-16);
+	EXPECT_NEAR(2*spline.coeffs()[1], 2*spline.coeffs()[4*8+1] + 6*spline.coeffs()[4*8]*dX[8], 1e-15);
+	spline.construct(X, Y, alfi::spline::CubicSpline<>::Types::ParabolicEnds{});
+	EXPECT_NEAR(0, spline.coeffs()[0], 1e-17);
+	EXPECT_NEAR(0, spline.coeffs()[4*8], 1e-17);
+	spline.construct(X, Y, alfi::spline::CubicSpline<>::Types::Clamped{-10, 10});
+	EXPECT_NEAR(-10, spline.coeffs()[2], 1e-14);
+	EXPECT_NEAR(10, spline.coeffs()[4*8+2] + 2*spline.coeffs()[4*8+1]*dX[8] + 3*spline.coeffs()[4*8]*dX[8]*dX[8], 1e-14);
+	spline.construct(X, Y, alfi::spline::CubicSpline<>::Types::FixedSecond{-10, 10});
+	EXPECT_NEAR(-10, 2*spline.coeffs()[1], 1e-17);
+	EXPECT_NEAR(10, 2*spline.coeffs()[4*8+1] + 6*spline.coeffs()[4*8]*dX[8], 1e-17);
+	spline.construct(X, Y, alfi::spline::CubicSpline<>::Types::FixedThird{-10, 10});
+	EXPECT_NEAR(-10, 6*spline.coeffs()[0], 1e-17);
+	EXPECT_NEAR(10, 6*spline.coeffs()[4*8], 1e-17);
+	spline.construct(X, Y, alfi::spline::CubicSpline<>::Types::NotAKnotStart{});
+	EXPECT_NEAR(spline.coeffs()[0], spline.coeffs()[4], 1e-17);
+	EXPECT_NEAR(spline.coeffs()[4], spline.coeffs()[8], 1e-17);
+	spline.construct(X, Y, alfi::spline::CubicSpline<>::Types::NotAKnotEnd{});
+	EXPECT_NEAR(spline.coeffs()[4*6], spline.coeffs()[4*7], 1e-14);
+	EXPECT_NEAR(spline.coeffs()[4*7], spline.coeffs()[4*8], 1e-15);
+}
+
+TEST(CubicSplineTest, CustomConditions) {
+	const size_t n = 10;
+	const double a = -1, b = 1;
+	const auto X = alfi::dist::uniform(n, a, b);
+	const auto dX = alfi::util::arrays::diff(X);
+	const auto Y = alfi::dist::circle_proj(n, a, b);
+	auto spline = alfi::spline::CubicSpline<>();
+	for (size_t i = 0; i < n; ++i) {
+		spline.construct(X, Y, alfi::spline::CubicSpline<>::Types::Custom{
+			alfi::spline::CubicSpline<>::Conditions::Clamped{i, 10},
+			alfi::spline::CubicSpline<>::Conditions::FixedSecond{i, 10}});
+		if (i < n - 1) {
+			EXPECT_NEAR(10, spline.coeffs()[4*i+2], 1e-17);
+			EXPECT_NEAR(10, 2*spline.coeffs()[4*i+1], 1e-17);
+		}
+		if (i > 0) {
+			EXPECT_NEAR(10, spline.coeffs()[4*(i-1)+2] + 2*spline.coeffs()[4*(i-1)+1]*dX[(i-1)] + 3*spline.coeffs()[4*(i-1)]*dX[(i-1)]*dX[(i-1)], 1e-13);
+			EXPECT_NEAR(10, 2*spline.coeffs()[4*(i-1)+1] + 6*spline.coeffs()[4*(i-1)]*dX[(i-1)], 1e-13);
+		}
+	}
+	for (size_t i = 0, j = 1; j < n; ++i, ++j) {
+		spline.construct(X, Y, alfi::spline::CubicSpline<>::Types::Custom{
+			alfi::spline::CubicSpline<>::Conditions::Clamped{i, 10},
+			alfi::spline::CubicSpline<>::Conditions::FixedSecond{j, 10}});
+		EXPECT_NEAR(10, spline.coeffs()[4*i+2], 1e-14);
+		if (i > 0) {
+			EXPECT_NEAR(10, spline.coeffs()[4*(i-1)+2] + 2*spline.coeffs()[4*(i-1)+1]*dX[(i-1)] + 3*spline.coeffs()[4*(i-1)]*dX[(i-1)]*dX[(i-1)], 1e-13);
+		}
+		if (j < n - 1) {
+			EXPECT_NEAR(10, 2*spline.coeffs()[4*j+1], 1e-13);
+		}
+		EXPECT_NEAR(10, 2*spline.coeffs()[4*(j-1)+1] + 6*spline.coeffs()[4*(j-1)]*dX[(j-1)], 1e-13);
+		spline.construct(X, Y, alfi::spline::CubicSpline<>::Types::Custom{
+			alfi::spline::CubicSpline<>::Conditions::FixedThird{i, 10},
+			alfi::spline::CubicSpline<>::Conditions::Clamped{j, 10}});
+		EXPECT_NEAR(10, 6*spline.coeffs()[4*i], 1e-17);
+		if (j < n - 1) {
+			EXPECT_NEAR(10, spline.coeffs()[4*j+2], 1e-14);
+		}
+		EXPECT_NEAR(10, spline.coeffs()[4*(j-1)+2] + 2*spline.coeffs()[4*(j-1)+1]*dX[(j-1)] + 3*spline.coeffs()[4*(j-1)]*dX[(j-1)]*dX[(j-1)], 1e-13);
+	}
+	spline.construct(X, Y, alfi::spline::CubicSpline<>::Types::Custom{
+		alfi::spline::CubicSpline<>::Conditions::NotAKnot{2},
+		alfi::spline::CubicSpline<>::Conditions::FixedSecond{5, 10}});
+	EXPECT_NEAR(spline.coeffs()[4*1], spline.coeffs()[4*2], 1e-17);
+	EXPECT_NEAR(10, 2*spline.coeffs()[4*5+1], 1e-14);
+	EXPECT_NEAR(10, 2*spline.coeffs()[4*4+1] + 6*spline.coeffs()[4*4]*dX[4], 1e-14);
+	spline.construct(X, Y, alfi::spline::CubicSpline<>::Types::Custom{
+		alfi::spline::CubicSpline<>::Conditions::NotAKnot{5},
+		alfi::spline::CubicSpline<>::Conditions::FixedThird{5, 10}});
+	EXPECT_NEAR(spline.coeffs()[4*4], spline.coeffs()[4*5], 1e-14);
+	EXPECT_NEAR(10, 6*spline.coeffs()[4*4], 1e-14);
+	EXPECT_NEAR(10, 6*spline.coeffs()[4*5], 1e-17);
 }
 
 TEST(CubicSplineTest, Moving) {


### PR DESCRIPTION
### Types of changes
- Feature

Related: #7 ALFI-lib/alfi-lib.github.io/pull/14

### Motivation
The ability to construct a spline with any two conditions is very interesting and can be used for more flexible spline construction, focusing on specific problems, as well as for studying the properties of splines.
This functionality is currently not implemented anywhere else, which makes the support for setting two arbitrary conditions for cubic splines a distinctive advantage of the library over its competitors.

### Description
- Added `Conditions` struct in `CubicSpline` with substructs:
  - `Clamped`;
  - `FixedSecond`;
  - `FixedThird`;
  - `NotAKnot`.
- Added `Custom` type.

Updated `compute_coeffs` function to support the ability to set two arbitrary conditions for cubic spline.

> [!NOTE]
> At the time, there is no option to equate derivatives or second derivatives at two points.
> So there is still only one non-customizable periodic condition.

### How to test
Added `CubicSplineTest.BasicConditions` and `CubicSplineTest.CustomConditions` unit tests.

Tested the changes with the following conditions using the `interpolation` example application.
```c++
{"Custom(NotAKnot(1), Clamped(1, 10))", alfi::spline::CubicSpline<>::Types::Custom{
	alfi::spline::CubicSpline<>::Conditions::NotAKnot{1},
	alfi::spline::CubicSpline<>::Conditions::Clamped{1, 10}}},
{"Custom(Clamped(1, 10), NotAKnot(1))", alfi::spline::CubicSpline<>::Types::Custom{
	alfi::spline::CubicSpline<>::Conditions::Clamped{1, 10},
	alfi::spline::CubicSpline<>::Conditions::NotAKnot{1}}},
{"Custom(FixedSecond(2, 5), FixedThird(2, -5))", alfi::spline::CubicSpline<>::Types::Custom{
	alfi::spline::CubicSpline<>::Conditions::FixedSecond{2, 5},
	alfi::spline::CubicSpline<>::Conditions::FixedThird{2, -5}}},
{"Custom(FixedThird(2, -5), FixedSecond(2, 5))", alfi::spline::CubicSpline<>::Types::Custom{
	alfi::spline::CubicSpline<>::Conditions::FixedThird{2, -5},
	alfi::spline::CubicSpline<>::Conditions::FixedSecond{2, 5}}},
{"Custom(Clamped(1, 10), FixedSecond(1, -10))", alfi::spline::CubicSpline<>::Types::Custom{
	alfi::spline::CubicSpline<>::Conditions::Clamped{1, 10},
	alfi::spline::CubicSpline<>::Conditions::FixedSecond{1, -10}}},
{"Custom(FixedSecond(1, -10)), Clamped(1, 10)", alfi::spline::CubicSpline<>::Types::Custom{
	alfi::spline::CubicSpline<>::Conditions::FixedSecond{1, -10},
	alfi::spline::CubicSpline<>::Conditions::Clamped{1, 10}}},
{"Custom(Clamped(2, 10)), Clamped(5, 10)", alfi::spline::CubicSpline<>::Types::Custom{
	alfi::spline::CubicSpline<>::Conditions::Clamped{2, 10},
	alfi::spline::CubicSpline<>::Conditions::Clamped{5, 10}}},
{"Custom(Clamped(2, 120)), Clamped(2, -100)", alfi::spline::CubicSpline<>::Types::Custom{
	alfi::spline::CubicSpline<>::Conditions::Clamped{2, 120},
	alfi::spline::CubicSpline<>::Conditions::Clamped{2, -100}}},
{"Custom(FixedSecond(2, 120)), FixedSecond(2, -100)", alfi::spline::CubicSpline<>::Types::Custom{
	alfi::spline::CubicSpline<>::Conditions::FixedSecond{2, 120},
	alfi::spline::CubicSpline<>::Conditions::FixedSecond{2, -100}}},
{"Custom(NotAKnot(2)), NotAKnot(2)", alfi::spline::CubicSpline<>::Types::Custom{
	alfi::spline::CubicSpline<>::Conditions::NotAKnot{2},
	alfi::spline::CubicSpline<>::Conditions::NotAKnot{2}}},
{"Custom(FixedThird(2, 120)), FixedThird(2, -100)", alfi::spline::CubicSpline<>::Types::Custom{
	alfi::spline::CubicSpline<>::Conditions::FixedThird{2, 120},
	alfi::spline::CubicSpline<>::Conditions::FixedThird{2, -100}}},
////// upd
{"Custom(NotAKnot(2), FixedThird(2, 10))", alfi::spline::CubicSpline<>::Types::Custom{
	alfi::spline::CubicSpline<>::Conditions::NotAKnot{2},
	alfi::spline::CubicSpline<>::Conditions::FixedThird{2, 10}}},
{"Custom(FixedSecond(0, 10), NotAKnot(1))", alfi::spline::CubicSpline<>::Types::Custom{
	alfi::spline::CubicSpline<>::Conditions::FixedSecond{0, 10},
	alfi::spline::CubicSpline<>::Conditions::NotAKnot{1}}},
{"Custom(FixedSecond(0, -5), Clamped(0, -10))", alfi::spline::CubicSpline<>::Types::Custom{
	alfi::spline::CubicSpline<>::Conditions::FixedSecond{0, -5},
	alfi::spline::CubicSpline<>::Conditions::Clamped{0, -10}}},
{"Custom(FixedSecond(5, -5), Clamped(5, -10))", alfi::spline::CubicSpline<>::Types::Custom{
	alfi::spline::CubicSpline<>::Conditions::FixedSecond{5, -5},
	alfi::spline::CubicSpline<>::Conditions::Clamped{5, -10}}},
```

### Future improvements
1. Implement customizable periodic conditions (equating derivatives or second derivatives at two points) (may be too complicated).
2. Investigate the possibility to remove the [special case with Clamped and FixedSecond](https://github.com/ALFI-lib/ALFI/pull/41/files#diff-6cc0c26284ce37c154f4cd7bcaa9f398fb7d774ef163bd618f87882f1d8743ffR355-R384) and use both conditions as "start" conditions, if the indices coincide.