### PR TITLE
Added clang-tidy.yml

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,50 @@
+name: Clang-Tidy
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  PROFILE: Debug
+  BUILD_DIR: build/debug
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: ./helper.py -d
+
+      - name: Build
+        run: ./helper.py -b ${{ env.PROFILE }}
+
+      - name: Install clang-tidy and tools
+        run: |
+          sudo apt install -y clang-tidy colorized-logs
+          cargo install clang-tidy-sarif
+
+      - name: Run clang-tidy
+        id: run-clang-tidy
+        run: |
+          set -o pipefail
+          files=$(find ALFI examples tests -path 'ALFI/*.h' -o -path 'examples/*.cpp' -o -path 'tests/*.cpp' ! -path '*deps/*')
+          clang-tidy -p ${{ env.BUILD_DIR }} --use-color $files 2>&1 |
+            sed "s|${{ github.workspace }}/||g" |
+            tee >(ansi2txt | clang-tidy-sarif > results.sarif)
+
+      - name: Upload results
+        if: success() || steps.run-clang-tidy.outcome == 'failure'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ set(CMAKE_CXX_FLAGS_FAST "-g0 -s -Ofast -fno-finite-math-only -flto=auto -DNDEBU
 set(CMAKE_CXX_FLAGS_FASTPARALLEL "-g0 -s -Ofast -fno-finite-math-only -flto=auto -fopenmp -DNDEBUG")
 set(CMAKE_CXX_FLAGS_SANITIZE "-g3 -fsanitize=address,leak,undefined")
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 add_subdirectory(ALFI)
 
 add_subdirectory(examples)


### PR DESCRIPTION
### Types of changes
- Configuration (CI/CD)

### Description
#### English
1. Added the `.github/workflows/clang-tidy.yml` file for code analysis using Clang-Tidy and uploading results to the GitHub Advanced Security service.

	Since the CMake configuration is not currently a separate step and occurs during project build with `helper.py -b [profile]`, the project is built before code analysis.
	This might seem redundant and could be removed in the future, but it may also be logical: there's no point in analyzing code with compilation errors.

	The default checks are used because extended check groups either turned out to be ineffective or, for some reason, caused `clang-tidy` to crash.

	- Analyzed files:
		- `ALFI/**/*.h`,
		- `examples/**/*.cpp`,
		- `tests/**/*.cpp`,
		- **Excluding** `**deps/**`.

		Header files in `tests` are not analyzed as they are not standalone.

	- Tools used:
		- `clang-tidy`: for code analysis.
		- `sed`: for converting absolute paths in the `clang-tidy` output to relative paths (necessary for proper code display in GitHub Advanced Security).
		- `ansi2txt` from `colorized-logs` package: for converting .ansi to .txt (removing colors from output).
		- `clang-tidy-sarif`: for converting `clang-tidy` output to SARIF.
		- `github/codeql-action/upload-sarif`: for uploading SARIF to GitHub.

	The step named "Run clang-tidy" with id `run-clang-tidy` fails if errors are found.
	The following "Upload results" step runs regardless of the success or failure of the previous step but will not run if the previous step was not run (e.g., if an error occurred in earlier steps or the workflow was canceled).

2. Enabled the `CMAKE_EXPORT_COMPILE_COMMANDS` setting in `CMakeLists.txt`, which is required for Clang-Tidy.

---

#### Russian
1. Добавлен файл `.github/workflows/clang-tidy.yml` для проверки кода с помощью инструмента Clang-Tidy и загрузки результатов в сервис GitHub Advanced Security.

	Поскольку конфигурация CMake на данный момент не выделена в отдельный шаг и происходит при сборке проекта с помощью `helper.py -b [profile]`, перед анализом кода происходит сборка проекта.
	Это может казаться излишним и может быть удалено в будущем. Хотя также может быть и логичным: нет смысла анализировать код проекта, содержащего ошибки компиляции.

	Используются проверки по умолчанию, потому что расширенные группы проверок либо оказались бесполезными, либо по каким-то причинам вызывали падение `clang-tidy`.

	- Анализируемые файлы:
		- `ALFI/**/*.h`,
		- `examples/**/*.cpp`,
		- `tests/**/*.cpp`,
		- **Исключая** `**deps/**`.

		Заголовочные файлы в `tests` не анализируются, потому что не являются самостоятельными.

	- Используемые инструменты:
		- `clang-tidy`: для анализа кода.
		- `sed`: для преобразования абсолютного пути в выводе `clang-tidy` в относительные (необходимо для правильного отображения кода в GitHub Advanced Security).
		- `ansi2txt` из пакета `colorized-logs`: для преобразованиия .ansi в .txt (удаления цветов из вывода).
		- `clang-tidy-sarif`: для преобразования вывода `clang-tidy` в SARIF.
		- `github/codeql-action/upload-sarif`: для загрузки SARIF в GitHub.

	Шаг с именем "Run clang-tidy" и id `run-clang-tidy` завершается неудачей, если найдены ошибки.
	Следующий шаг "Upload results" выполняется независимо от успеха или неудачи предыдущего шага, но не выполняется, если предыдущий шаг не был запущен (например, если ошибка произошла на более ранних шагах или workflow был отменён).

2. Включена настройка `CMAKE_EXPORT_COMPILE_COMMANDS` в `CMakeLists.txt`, которая требуется Clang-Tidy.

### Future improvements
- Optimize workflow runtime.