### PR TITLE
feat(bary): Applied Chebyshev first kind weights to stretched version

### DIFF
--- a/ALFI/ALFI/misc.h
+++ b/ALFI/ALFI/misc.h
@@ -53,7 +53,7 @@ namespace alfi::misc {
 			// for (SizeT j = 0; j < N; ++j) {
 			// 	W[j] /= norm_factor;
 			// }
-		} else if (dist_type == dist::Type::CHEBYSHEV) {
+		} else if (dist_type == dist::Type::CHEBYSHEV || dist_type == dist::Type::CHEBYSHEV_STRETCHED) {
 			for (SizeT j = 0; j < N; ++j) {
 				W[j] = (j % 2 == 0 ? 1 : -1) * std::sin(((2 * static_cast<Number>(j) + 1) * M_PI) / (2 * static_cast<Number>(N)));
 			}


### PR DESCRIPTION
### Types of changes
- Feature

Related: #5 https://github.com/ALFI-lib/alfi-lib.github.io/pull/17

### Description
Barycentric weights remain unchanged under interval scaling, so they are the same for stretched nodes.