### PR TITLE
feat(dist,bary): Added stretched versions for third and fourth kind Chebyshev nodes

### DIFF
--- a/ALFI/ALFI/dist.h
+++ b/ALFI/ALFI/dist.h
@@ -16,13 +16,17 @@ namespace alfi::dist {
 		CHEBYSHEV_AUGMENTED,
 		CHEBYSHEV_2,
 		CHEBYSHEV_3,
+		CHEBYSHEV_3_STRETCHED,
 		CHEBYSHEV_4,
+		CHEBYSHEV_4_STRETCHED,
 		CHEBYSHEV_ELLIPSE,
 		CHEBYSHEV_ELLIPSE_STRETCHED,
 		CHEBYSHEV_ELLIPSE_AUGMENTED,
 		CHEBYSHEV_ELLIPSE_2,
 		CHEBYSHEV_ELLIPSE_3,
+		CHEBYSHEV_ELLIPSE_3_STRETCHED,
 		CHEBYSHEV_ELLIPSE_4,
+		CHEBYSHEV_ELLIPSE_4_STRETCHED,
 		LOGISTIC,
 		LOGISTIC_STRETCHED,
 		ERF,
@@ -155,6 +159,11 @@ namespace alfi::dist {
 	}
 
 	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
+	Container<Number> chebyshev_3_stretched(SizeT n, Number a, Number b) {
+		return points::stretched<Number,Container>(chebyshev_3(n, a, b), a, b);
+	}
+
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> chebyshev_4(SizeT n, Number a, Number b) {
 		Container<Number> points(n);
 		for (SizeT i = 0; i < n; ++i) {
@@ -162,6 +171,11 @@ namespace alfi::dist {
 			points[i] = a + (b - a) * x / 2;
 		}
 		return points;
+	}
+
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
+	Container<Number> chebyshev_4_stretched(SizeT n, Number a, Number b) {
+		return points::stretched<Number,Container>(chebyshev_4(n, a, b), a, b);
 	}
 
 	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
@@ -225,6 +239,11 @@ namespace alfi::dist {
 	}
 
 	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
+	Container<Number> chebyshev_ellipse_3_stretched(SizeT n, Number a, Number b, Number ratio) {
+		return points::stretched<Number,Container>(chebyshev_ellipse_3(n, a, b, ratio), a, b);
+	}
+
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
 	Container<Number> chebyshev_ellipse_4(SizeT n, Number a, Number b, Number ratio) {
 		Container<Number> points(n);
 		for (SizeT i = 0; i < n; ++i) {
@@ -233,6 +252,11 @@ namespace alfi::dist {
 			points[i] = (1 - x) * (b - a) / 2 + a;
 		}
 		return points;
+	}
+
+	template <typename Number = DefaultNumber, template <typename, typename...> class Container = DefaultContainer>
+	Container<Number> chebyshev_ellipse_4_stretched(SizeT n, Number a, Number b, Number ratio) {
+		return points::stretched<Number,Container>(chebyshev_ellipse_4(n, a, b, ratio), a, b);
 	}
 
 	/**
@@ -350,8 +374,12 @@ namespace alfi::dist {
 			return chebyshev_2(n, a, b);
 		case Type::CHEBYSHEV_3:
 			return chebyshev_3(n, a, b);
+		case Type::CHEBYSHEV_3_STRETCHED:
+			return chebyshev_3_stretched(n, a, b);
 		case Type::CHEBYSHEV_4:
 			return chebyshev_4(n, a, b);
+		case Type::CHEBYSHEV_4_STRETCHED:
+			return chebyshev_4_stretched(n, a, b);
 		case Type::CHEBYSHEV_ELLIPSE:
 			return chebyshev_ellipse(n, a, b, parameter);
 		case Type::CHEBYSHEV_ELLIPSE_STRETCHED:
@@ -362,8 +390,12 @@ namespace alfi::dist {
 			return chebyshev_ellipse_2(n, a, b, parameter);
 		case Type::CHEBYSHEV_ELLIPSE_3:
 			return chebyshev_ellipse_3(n, a, b, parameter);
+		case Type::CHEBYSHEV_ELLIPSE_3_STRETCHED:
+			return chebyshev_ellipse_3_stretched(n, a, b, parameter);
 		case Type::CHEBYSHEV_ELLIPSE_4:
 			return chebyshev_ellipse_4(n, a, b, parameter);
+		case Type::CHEBYSHEV_ELLIPSE_4_STRETCHED:
+			return chebyshev_ellipse_4_stretched(n, a, b, parameter);
 		case Type::LOGISTIC:
 			return logistic(n, a, b, parameter);
 		case Type::LOGISTIC_STRETCHED:

--- a/ALFI/ALFI/misc.h
+++ b/ALFI/ALFI/misc.h
@@ -70,14 +70,14 @@ namespace alfi::misc {
 					W[j] /= 2;
 				}
 			}
-		} else if (dist_type == dist::Type::CHEBYSHEV_3) {
+		} else if (dist_type == dist::Type::CHEBYSHEV_3 || dist_type == dist::Type::CHEBYSHEV_3_STRETCHED) {
 			for (SizeT j = 0; j < N; ++j) {
 				W[j] = (j % 2 == 0 ? 1 : -1) * std::cos((static_cast<Number>(2*j) * M_PI) / static_cast<Number>(2*N - 1) / 2);
 				if (j == 0) {
 					W[j] /= 2;
 				}
 			}
-		} else if (dist_type == dist::Type::CHEBYSHEV_4) {
+		} else if (dist_type == dist::Type::CHEBYSHEV_4 || dist_type == dist::Type::CHEBYSHEV_4_STRETCHED) {
 			for (SizeT j = 0; j < N; ++j) {
 				W[j] = (j % 2 == 0 ? 1 : -1) * std::sin((static_cast<Number>(2*j + 1) * M_PI) / static_cast<Number>(2*N - 1) / 2);
 				if (j == N - 1) {

--- a/examples/interpolation/interpolation.cpp
+++ b/examples/interpolation/interpolation.cpp
@@ -84,10 +84,10 @@ public:
 
 	PlotWindow() {
 		static const QStringList distribution_types {
-			"Uniform", "Quadratic", "Cubic", "Chebyshev", "Stretched Chebyshev", "Augmented Chebyshev",
-			"Chebyshev Second Kind", "Chebyshev Third Kind", "Chebyshev Fourth Kind",
-			"Chebyshev Ellipse", "Stretched Chebyshev Ellipse", "Augmented Chebyshev Ellipse",
-			"Chebyshev Ellipse Second Kind", "Chebyshev Ellipse Third Kind", "Chebyshev Ellipse Fourth Kind",
+			"Uniform", "Quadratic", "Cubic", "Chebyshev", "Stretched Chebyshev", "Augmented Chebyshev", "Chebyshev Second Kind",
+			"Chebyshev Third Kind", "Stretched Chebyshev Third Kind", "Chebyshev Fourth Kind", "Stretched Chebyshev Fourth Kind",
+			"Chebyshev Ellipse", "Stretched Chebyshev Ellipse", "Augmented Chebyshev Ellipse", "Chebyshev Ellipse Second Kind",
+			"Chebyshev Ellipse Third Kind", "Stretched Chebyshev Ellipse Third Kind", "Chebyshev Ellipse Fourth Kind", "Stretched Chebyshev Ellipse Fourth Kind",
 			"Logistic", "Stretched Logistic", "Error Function", "Stretched Error Function"
 		};
 
@@ -283,13 +283,17 @@ private:
 			case alfi::dist::Type::CHEBYSHEV_AUGMENTED: X = alfi::dist::chebyshev_augmented(N, a, b); break;
 			case alfi::dist::Type::CHEBYSHEV_2: X = alfi::dist::chebyshev_2(N, a, b); break;
 			case alfi::dist::Type::CHEBYSHEV_3: X = alfi::dist::chebyshev_3(N, a, b); break;
+			case alfi::dist::Type::CHEBYSHEV_3_STRETCHED: X = alfi::dist::chebyshev_3_stretched(N, a, b); break;
 			case alfi::dist::Type::CHEBYSHEV_4: X = alfi::dist::chebyshev_4(N, a, b); break;
+			case alfi::dist::Type::CHEBYSHEV_4_STRETCHED: X = alfi::dist::chebyshev_4_stretched(N, a, b); break;
 			case alfi::dist::Type::CHEBYSHEV_ELLIPSE: X = alfi::dist::chebyshev_ellipse(N, a, b, 2.0); break;
 			case alfi::dist::Type::CHEBYSHEV_ELLIPSE_STRETCHED: X = alfi::dist::chebyshev_ellipse_stretched(N, a, b, 2.0); break;
 			case alfi::dist::Type::CHEBYSHEV_ELLIPSE_AUGMENTED: X = alfi::dist::chebyshev_ellipse_augmented(N, a, b, 2.0); break;
 			case alfi::dist::Type::CHEBYSHEV_ELLIPSE_2: X = alfi::dist::chebyshev_ellipse_2(N, a, b, 2.0); break;
 			case alfi::dist::Type::CHEBYSHEV_ELLIPSE_3: X = alfi::dist::chebyshev_ellipse_3(N, a, b, 2.0); break;
+			case alfi::dist::Type::CHEBYSHEV_ELLIPSE_3_STRETCHED: X = alfi::dist::chebyshev_ellipse_3_stretched(N, a, b, 2.0); break;
 			case alfi::dist::Type::CHEBYSHEV_ELLIPSE_4: X = alfi::dist::chebyshev_ellipse_4(N, a, b, 2.0); break;
+			case alfi::dist::Type::CHEBYSHEV_ELLIPSE_4_STRETCHED: X = alfi::dist::chebyshev_ellipse_4_stretched(N, a, b, 2.0); break;
 			case alfi::dist::Type::LOGISTIC: X = alfi::dist::logistic(N, a, b, 16.0); break;
 			case alfi::dist::Type::LOGISTIC_STRETCHED: X = alfi::dist::logistic_stretched(N, a, b, 16.0); break;
 			case alfi::dist::Type::ERF: X = alfi::dist::erf(N, a, b, 8.0); break;

--- a/tests/dist/test_dist.cpp
+++ b/tests/dist/test_dist.cpp
@@ -66,8 +66,16 @@ TEST(DistributionsTest, Chebyshev3) {
 	test_distribution("chebyshev_3", alfi::dist::Type::CHEBYSHEV_3, 1e-15);
 }
 
+TEST(DistributionsTest, Chebyshev3Stretched) {
+	test_distribution("chebyshev_3_stretched", alfi::dist::Type::CHEBYSHEV_3_STRETCHED, 1e-15);
+}
+
 TEST(DistributionsTest, Chebyshev4) {
 	test_distribution("chebyshev_4", alfi::dist::Type::CHEBYSHEV_4, 1e-15);
+}
+
+TEST(DistributionsTest, Chebyshev4Stretched) {
+	test_distribution("chebyshev_4_stretched", alfi::dist::Type::CHEBYSHEV_4_STRETCHED, 1e-15);
 }
 
 TEST(DistributionsTest, ChebyshevEllipse) {
@@ -90,8 +98,16 @@ TEST(DistributionsTest, ChebyshevEllipse3) {
 	test_distribution("chebyshev_ellipse_3", alfi::dist::Type::CHEBYSHEV_ELLIPSE_3, 1e-13);
 }
 
+TEST(DistributionsTest, ChebyshevEllipse3Stretched) {
+	test_distribution("chebyshev_ellipse_3_stretched", alfi::dist::Type::CHEBYSHEV_ELLIPSE_3_STRETCHED, 1e-13);
+}
+
 TEST(DistributionsTest, ChebyshevEllipse4) {
 	test_distribution("chebyshev_ellipse_4", alfi::dist::Type::CHEBYSHEV_ELLIPSE_4, 1e-14);
+}
+
+TEST(DistributionsTest, ChebyshevEllipse4Stretched) {
+	test_distribution("chebyshev_ellipse_4_stretched", alfi::dist::Type::CHEBYSHEV_ELLIPSE_4_STRETCHED, 1e-13);
 }
 
 TEST(DistributionsTest, Logistic) {


### PR DESCRIPTION
### Types of changes
- Feature
- Testing

Related: #56 https://github.com/ALFI-lib/test_data/pull/8

### Description
- Added `chebyshev(_ellipse)?_(3|4)_stretched` point distributions.
- Updated `alfi::misc::barycentric` to handle `chebyshev_(3|4)_stretched` distributions with stable formulas (the same as for `chebyshev(3|4)`).
- Updated tests.