### PR TITLE
bench: Introduced benchmarks

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -38,7 +38,7 @@ jobs:
         id: run-clang-tidy
         run: |
           set -o pipefail
-          files=$(find ALFI examples tests -path 'ALFI/*.h' -o -path 'examples/*.cpp' -o -path 'tests/*.cpp' ! -path '*deps/*')
+          files=$(find ALFI examples tests benches -path 'ALFI/*.h' -o -path 'examples/*.cpp' -o -path 'tests/*.cpp' -o -path 'benches/*.cpp' ! -path '*deps/*')
           clang-tidy -p ${{ env.BUILD_DIR }} --use-color $files 2>&1 |
             sed "s|${{ github.workspace }}/||g" |
             tee >(ansi2txt | clang-tidy-sarif > results.sarif)

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
+[submodule "benches/deps/benchmark"]
+	path = benches/deps/benchmark
+	url = https://github.com/google/benchmark
+	shallow = true
 [submodule "tests/deps/toml++"]
 	path = tests/deps/toml++
 	url = https://github.com/pasabanov/tomlpp-min

--- a/.idea/runConfigurations/bench_barycentric.xml
+++ b/.idea/runConfigurations/bench_barycentric.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="bench_barycentric" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="--benchmark_color=yes --benchmark_counters_tabular=yes" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="ALFI" TARGET_NAME="bench_barycentric" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="ALFI" RUN_TARGET_NAME="bench_barycentric">
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.idea/runConfigurations/bench_cubic.xml
+++ b/.idea/runConfigurations/bench_cubic.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="bench_cubic" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="--benchmark_color=yes --benchmark_counters_tabular=yes" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="ALFI" TARGET_NAME="bench_cubic" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="ALFI" RUN_TARGET_NAME="bench_cubic">
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.idea/runConfigurations/bench_linear.xml
+++ b/.idea/runConfigurations/bench_linear.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="bench_linear" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="--benchmark_color=yes --benchmark_counters_tabular=yes" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="ALFI" TARGET_NAME="bench_linear" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="ALFI" RUN_TARGET_NAME="bench_linear">
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.idea/runConfigurations/bench_poly.xml
+++ b/.idea/runConfigurations/bench_poly.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="bench_poly" type="CMakeRunConfiguration" factoryName="Application" nameIsGenerated="true" PROGRAM_PARAMS="--benchmark_color=yes --benchmark_counters_tabular=yes" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="ALFI" TARGET_NAME="bench_poly" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="ALFI" RUN_TARGET_NAME="bench_poly">
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.idea/runConfigurations/bench_quadratic.xml
+++ b/.idea/runConfigurations/bench_quadratic.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="bench_quadratic" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="--benchmark_color=yes --benchmark_counters_tabular=yes" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="ALFI" TARGET_NAME="bench_quadratic" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="ALFI" RUN_TARGET_NAME="bench_quadratic">
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.idea/runConfigurations/bench_step.xml
+++ b/.idea/runConfigurations/bench_step.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="bench_step" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="--benchmark_color=yes --benchmark_counters_tabular=yes" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="ALFI" TARGET_NAME="bench_step" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="ALFI" RUN_TARGET_NAME="bench_step">
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,3 +26,5 @@ add_subdirectory(examples)
 
 enable_testing()
 add_subdirectory(tests)
+
+add_subdirectory(benches)

--- a/benches/CMakeLists.txt
+++ b/benches/CMakeLists.txt
@@ -1,0 +1,21 @@
+set(CMAKE_CXX_STANDARD 23)
+
+set(ORIGINAL_CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}")
+set(CMAKE_BUILD_TYPE Release)
+set(BENCHMARK_ENABLE_INSTALL OFF)
+set(BENCHMARK_ENABLE_TESTING OFF)
+set(BENCHMARK_ENABLE_LTO ON)
+add_subdirectory(deps/benchmark)
+set(CMAKE_BUILD_TYPE "${ORIGINAL_CMAKE_BUILD_TYPE}")
+
+macro(add_bench_executable bench_name)
+	add_executable(${bench_name} ${ARGN} bench_utils.h bench_data.h)
+	target_link_libraries(${bench_name} PRIVATE ALFI benchmark::benchmark)
+endmacro()
+
+add_bench_executable(bench_poly poly/bench_poly.cpp)
+add_bench_executable(bench_barycentric misc/bench_barycentric.cpp)
+add_bench_executable(bench_step spline/bench_step.cpp)
+add_bench_executable(bench_linear spline/bench_linear.cpp)
+add_bench_executable(bench_quadratic spline/bench_quadratic.cpp)
+add_bench_executable(bench_cubic spline/bench_cubic.cpp)

--- a/benches/bench_data.h
+++ b/benches/bench_data.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cmath>
+#include <functional>
+#include <vector>
+
+#include <ALFI/dist.h>
+
+using FuncName = std::string;
+using Lambda = std::function<double(double)>;
+using Function = std::pair<FuncName, Lambda>;
+using Interval = std::pair<double, double>;
+
+/**
+	@brief Collection of functions with their interpolation intervals.
+
+	Each entry consists of:
+	- Function: pair (`std::pair`) containing:
+	  - Name (`std::string`).
+	  - Lambda function (`std::function<double(double)>`).
+	- Interval: range (`std::pair<double, double>`).
+*/
+const std::vector<std::pair<Function, Interval>> funcs_and_ints = {
+	{{"exp", [](double x) { return std::exp(x); }}, {-3, 3}},
+	{{"sin", [](double x) { return std::sin(x); }}, {-M_PI, M_PI}},
+	{{"cos", [](double x) { return std::cos(x); }}, {-M_PI, M_PI}},
+	{{"f1", [](double x) { return std::abs(x) + x/2 - x*x; }}, {-1, 1}},
+	{{"f2", [](double x) { return -3*std::sin(10*x) + 10*sin(std::abs(x) + x/2); }}, {-10, 10}},
+};
+
+const std::vector<alfi::dist::Type> dists = {
+	alfi::dist::Type::UNIFORM,
+	alfi::dist::Type::CHEBYSHEV,
+	alfi::dist::Type::CHEBYSHEV_2,
+};
+
+const int64_t nn = 10000;

--- a/benches/bench_utils.h
+++ b/benches/bench_utils.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <random>
+#include <vector>
+
+#include <benchmark/benchmark.h>
+
+#include <ALFI/util/arrays.h>
+#include <ALFI/util/stat.h>
+
+template <typename T>
+T random_value(T min, T max) {
+	static std::mt19937_64 generator(std::random_device{}());
+
+	if constexpr (std::is_integral_v<T>) {
+		static std::uniform_int_distribution<T> dist(min, max);
+		return dist(generator);
+	} else if constexpr (std::is_floating_point_v<T>) {
+		static std::uniform_real_distribution<T> dist(min, max);
+		return dist(generator);
+	} else {
+		static_assert(false, "Unsupported type: must be integral or floating-point");
+		return {};
+	}
+}
+
+template <typename T, typename F>
+std::vector<T> apply_func(const std::vector<T>& input, F func) {
+	std::vector<T> result(input.size());
+	std::transform(input.begin(), input.end(), result.begin(), func);
+	return result;
+}
+
+template <typename T, typename V1, typename V2>
+std::vector<T> concat_vectors(V1&& a, V2&& b) {
+	std::vector<T> result = std::forward<V1>(a);
+	result.reserve(std::size(a) + std::size(b));
+	result.insert(result.end(), std::make_move_iterator(std::begin(b)), std::make_move_iterator(std::end(b)));
+	return result;
+}
+
+template <typename T>
+void add_error_metrics(benchmark::State& state, const std::vector<T>& result, const std::vector<T>& expected) {
+	const std::vector<double> error = alfi::util::arrays::sub(result, expected);
+	state.counters["1.ME"] = alfi::util::stat::mean(error);
+	state.counters["2.MAE"] = alfi::util::stat::mean_abs(error);
+	state.counters["3.RMSE"] = alfi::util::stat::rms(error);
+	state.counters["4.Variance"] = alfi::util::stat::var(error);
+}

--- a/benches/misc/bench_barycentric.cpp
+++ b/benches/misc/bench_barycentric.cpp
@@ -1,0 +1,56 @@
+#include <benchmark/benchmark.h>
+
+#include <ALFI/misc.h>
+
+#include "../bench_utils.h"
+#include "../bench_data.h"
+
+static void BM_barycentric(benchmark::State& state) {
+	const auto& [func_name, lambda] = funcs_and_ints[state.range(0)].first;
+	const auto& interval = funcs_and_ints[state.range(0)].second;
+	const auto& dist_type = dists[state.range(1)];
+	const auto& n = state.range(2);
+	const auto& nn = state.range(3);
+	const std::vector<double> X = of_type<double>(dist_type, n, interval.first, interval.second);
+	const std::vector<double> Y = apply_func(X, lambda);
+	const std::vector<double> xx = of_type<double>(alfi::dist::Type::UNIFORM, nn, interval.first, interval.second);
+	std::vector<double> result;
+	for (auto _ : state) {
+		result = alfi::misc::barycentric(X, Y, xx, dist_type);
+		benchmark::DoNotOptimize(result);
+		benchmark::ClobberMemory();
+	}
+	const std::vector<double> expected = apply_func(xx, lambda);
+	add_error_metrics(state, result, expected);
+}
+
+BENCHMARK(BM_barycentric)
+	->ArgsProduct({
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(funcs_and_ints.size()) - 1, 1),
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(dists.size()) - 1, 1),
+		benchmark::CreateRange(8, 32, 2),
+		{nn},
+	})
+	->ArgNames({"func", "dist", "n", "nn"});
+
+BENCHMARK(BM_barycentric)
+	->Name("BM_barycentric_chebyshev")
+	->ArgsProduct({
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(funcs_and_ints.size()) - 1, 1),
+		{1},
+		benchmark::CreateRange(1 << 6, 1 << 21, 1 << 3),
+		{nn},
+	})
+	->ArgNames({"func", "dist", "n", "nn"});
+
+BENCHMARK(BM_barycentric)
+	->Name("BM_barycentric_chebyshev_2")
+	->ArgsProduct({
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(funcs_and_ints.size()) - 1, 1),
+		{2},
+		benchmark::CreateRange(1 << 6, 1 << 21, 1 << 3),
+		{nn},
+	})
+	->ArgNames({"func", "dist", "n", "nn"});
+
+BENCHMARK_MAIN();

--- a/benches/poly/bench_poly.cpp
+++ b/benches/poly/bench_poly.cpp
@@ -1,0 +1,134 @@
+#include <benchmark/benchmark.h>
+
+#include <ALFI/poly.h>
+
+#include "../bench_utils.h"
+#include "../bench_data.h"
+
+static void BM_val_scalar(benchmark::State& state) {
+	std::vector<double> coeffs(state.range(0));
+	for (auto& coeff : coeffs) {
+		coeff = random_value<double>(-1, 1);
+	}
+	const auto x = random_value<double>(-1, 1);
+	double result;
+	for (auto _ : state) {
+		result = alfi::poly::val(coeffs, x);
+		benchmark::DoNotOptimize(result);
+		benchmark::ClobberMemory();
+	}
+}
+
+static void BM_val_vector(benchmark::State& state) {
+	std::vector<double> coeffs(state.range(0));
+	for (auto& coeff : coeffs) {
+		coeff = random_value<double>(-1, 1);
+	}
+	std::vector<double> xx(state.range(1));
+	for (auto& x : xx) {
+		x = random_value<double>(-1, 1);
+	}
+	std::vector<double> result;
+	for (auto _ : state) {
+		result = alfi::poly::val(coeffs, xx);
+		benchmark::DoNotOptimize(result);
+		benchmark::ClobberMemory();
+	}
+}
+
+template <auto interp>
+static void BM_interp_poly(benchmark::State& state) {
+	const auto& [func_name, lambda] = funcs_and_ints[state.range(0)].first;
+	const auto& interval = funcs_and_ints[state.range(0)].second;
+	const auto& dist_type = dists[state.range(1)];
+	const auto& n = state.range(2);
+	const auto& nn = state.range(3);
+	const std::vector<double> X = of_type<double>(dist_type, n, interval.first, interval.second);
+	const std::vector<double> Y = apply_func(X, lambda);
+	std::vector<double> coeffs;
+	for (auto _ : state) {
+		coeffs = interp(X, Y);
+		benchmark::DoNotOptimize(coeffs);
+		benchmark::ClobberMemory();
+	}
+	const std::vector<double> xx = of_type<double>(alfi::dist::Type::UNIFORM, nn, interval.first, interval.second);
+	const std::vector<double> expected = apply_func(xx, lambda);
+	const std::vector<double> result = alfi::poly::val(coeffs, xx);
+	add_error_metrics(state, result, expected);
+}
+
+template <auto interp>
+static void BM_interp_poly_vals(benchmark::State& state) {
+	const auto& [func_name, lambda] = funcs_and_ints[state.range(0)].first;
+	const auto& interval = funcs_and_ints[state.range(0)].second;
+	const auto& dist_type = dists[state.range(1)];
+	const auto& n = state.range(2);
+	const auto& nn = state.range(3);
+	const std::vector<double> X = of_type<double>(dist_type, n, interval.first, interval.second);
+	const std::vector<double> Y = apply_func(X, lambda);
+	const std::vector<double> xx = of_type<double>(alfi::dist::Type::UNIFORM, nn, interval.first, interval.second);
+	std::vector<double> result;
+	for (auto _ : state) {
+		result = interp(X, Y, xx);
+		benchmark::DoNotOptimize(result);
+		benchmark::ClobberMemory();
+	}
+	const std::vector<double> expected = apply_func(xx, lambda);
+	add_error_metrics(state, result, expected);
+}
+
+// need special function for `imp_lagrange_vals` because of the fourth parameter
+static void BM_imp_lagrange_vals(benchmark::State& state) {
+	const auto& [func_name, lambda] = funcs_and_ints[state.range(0)].first;
+	const auto& interval = funcs_and_ints[state.range(0)].second;
+	const auto& dist_type = dists[state.range(1)];
+	const auto& n = state.range(2);
+	const auto& nn = state.range(3);
+	const std::vector<double> X = of_type<double>(dist_type, n, interval.first, interval.second);
+	const std::vector<double> Y = apply_func(X, lambda);
+	const std::vector<double> xx = of_type<double>(alfi::dist::Type::UNIFORM, nn, interval.first, interval.second);
+	std::vector<double> result;
+	for (auto _ : state) {
+		result = alfi::poly::imp_lagrange_vals(X, Y, xx);
+		benchmark::DoNotOptimize(result);
+		benchmark::ClobberMemory();
+	}
+	const std::vector<double> expected = apply_func(xx, lambda);
+	add_error_metrics(state, result, expected);
+}
+
+namespace {
+	struct BenchmarkRegistrar {
+		BenchmarkRegistrar() {
+			RegisterBenchmark("BM_val_scalar", BM_val_scalar)
+				->Range(1 << 3, 1 << 12)
+				->ArgName("n");
+			RegisterBenchmark("BM_val_vector", BM_val_vector)
+				->Ranges({{1 << 3, 1 << 12}, {1 << 3, 1 << 12}})
+				->ArgNames({"n", "nn"});
+
+			const std::vector<std::pair<std::string, std::function<void(benchmark::State&)>>> regsPoly = {
+				{"BM_lagrange", [](benchmark::State& state) { BM_interp_poly<alfi::poly::lagrange<>>(state); }},
+				{"BM_imp_lagrange", [](benchmark::State& state) { BM_interp_poly<alfi::poly::imp_lagrange<>>(state); }},
+				{"BM_newton", [](benchmark::State& state) { BM_interp_poly<alfi::poly::newton<>>(state); }},
+				{"BM_lagrange_vals", [](benchmark::State& state) { BM_interp_poly_vals<alfi::poly::lagrange_vals<>>(state); }},
+				{"BM_imp_lagrange_vals", BM_imp_lagrange_vals},
+				{"BM_newton_vals", [](benchmark::State& state) { BM_interp_poly_vals<alfi::poly::newton_vals<>>(state); }},
+			};
+			for (const auto& [name, function] : regsPoly) {
+				RegisterBenchmark(name, function)
+					->ArgsProduct({
+						benchmark::CreateDenseRange(0, static_cast<int64_t>(funcs_and_ints.size()) - 1, 1),
+						benchmark::CreateDenseRange(0, static_cast<int64_t>(dists.size()) - 1, 1),
+						benchmark::CreateRange(8, 32, 2),
+						{nn},
+					})
+					->ArgNames({"func", "dist", "n", "nn"});
+			}
+		}
+	};
+
+	[[maybe_unused]] const BenchmarkRegistrar registrar;
+}
+
+BENCHMARK_MAIN();

--- a/benches/spline/bench_cubic.cpp
+++ b/benches/spline/bench_cubic.cpp
@@ -1,0 +1,68 @@
+#include <benchmark/benchmark.h>
+
+#include <ALFI/spline/cubic.h>
+
+#include "../bench_utils.h"
+#include "../bench_data.h"
+
+const std::vector<alfi::spline::CubicSpline<>::Type> cubic_spline_types = {
+	alfi::spline::CubicSpline<>::Types::Natural{},
+	alfi::spline::CubicSpline<>::Types::NotAKnot{},
+	alfi::spline::CubicSpline<>::Types::ParabolicEnds{},
+};
+
+static void BM_cubic_spline(benchmark::State& state) {
+	const auto& [func_name, lambda] = funcs_and_ints[state.range(0)].first;
+	const auto& interval = funcs_and_ints[state.range(0)].second;
+	const auto& dist_type = dists[state.range(1)];
+	const auto& n = state.range(2);
+	const auto& type = cubic_spline_types[state.range(3)];
+	const std::vector<double> X = of_type<double>(dist_type, n, interval.first, interval.second);
+	const std::vector<double> Y = apply_func(X, lambda);
+	alfi::spline::CubicSpline<> spline;
+	for (auto _ : state) {
+		spline = alfi::spline::CubicSpline<>(X, Y, type);
+		benchmark::DoNotOptimize(spline);
+		benchmark::ClobberMemory();
+	}
+}
+BENCHMARK(BM_cubic_spline)
+	->ArgsProduct({
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(funcs_and_ints.size()) - 1, 1),
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(dists.size()) - 1, 1),
+		benchmark::CreateRange(1 << 6, 1 << 21, 1 << 3),
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(cubic_spline_types.size()) - 1, 1),
+	})
+	->ArgNames({"func", "dist", "n", "type"});
+
+static void BM_cubic_spline_values(benchmark::State& state) {
+	const auto& [func_name, lambda] = funcs_and_ints[state.range(0)].first;
+	const auto& interval = funcs_and_ints[state.range(0)].second;
+	const auto& dist_type = dists[state.range(1)];
+	const auto& n = state.range(2);
+	const auto& nn = state.range(3);
+	const auto& type = cubic_spline_types[state.range(4)];
+	const std::vector<double> X = of_type<double>(dist_type, n, interval.first, interval.second);
+	const std::vector<double> Y = apply_func(X, lambda);
+	const std::vector<double> xx = of_type<double>(alfi::dist::Type::UNIFORM, nn, interval.first, interval.second);
+	const alfi::spline::CubicSpline<> spline(X, Y, type);
+	std::vector<double> result;
+	for (auto _ : state) {
+		result = spline.eval(xx);
+		benchmark::DoNotOptimize(result);
+		benchmark::ClobberMemory();
+	}
+	const std::vector<double> expected = apply_func(xx, lambda);
+	add_error_metrics(state, result, expected);
+}
+BENCHMARK(BM_cubic_spline_values)
+	->ArgsProduct({
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(funcs_and_ints.size()) - 1, 1),
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(dists.size()) - 1, 1),
+		concat_vectors<int64_t>(benchmark::CreateRange(8, 32, 2), benchmark::CreateRange(1 << 6, 1 << 21, 1 << 3)),
+		{nn},
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(cubic_spline_types.size()) - 1, 1),
+	})
+	->ArgNames({"func", "dist", "n", "nn", "type"});
+
+BENCHMARK_MAIN();

--- a/benches/spline/bench_linear.cpp
+++ b/benches/spline/bench_linear.cpp
@@ -1,0 +1,58 @@
+#include <benchmark/benchmark.h>
+
+#include <ALFI/spline/linear.h>
+
+#include "../bench_utils.h"
+#include "../bench_data.h"
+
+static void BM_linear_spline(benchmark::State& state) {
+	const auto& [func_name, lambda] = funcs_and_ints[state.range(0)].first;
+	const auto& interval = funcs_and_ints[state.range(0)].second;
+	const auto& dist_type = dists[state.range(1)];
+	const auto& n = state.range(2);
+	const std::vector<double> X = of_type<double>(dist_type, n, interval.first, interval.second);
+	const std::vector<double> Y = apply_func(X, lambda);
+	alfi::spline::LinearSpline<> spline;
+	for (auto _ : state) {
+		spline = alfi::spline::LinearSpline<>(X, Y);
+		benchmark::DoNotOptimize(spline);
+		benchmark::ClobberMemory();
+	}
+}
+BENCHMARK(BM_linear_spline)
+	->ArgsProduct({
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(funcs_and_ints.size()) - 1, 1),
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(dists.size()) - 1, 1),
+		benchmark::CreateRange(1 << 6, 1 << 21, 1 << 3),
+	})
+	->ArgNames({"func", "dist", "n"});
+
+static void BM_linear_spline_values(benchmark::State& state) {
+	const auto& [func_name, lambda] = funcs_and_ints[state.range(0)].first;
+	const auto& interval = funcs_and_ints[state.range(0)].second;
+	const auto& dist_type = dists[state.range(1)];
+	const auto& n = state.range(2);
+	const auto& nn = state.range(3);
+	const std::vector<double> X = of_type<double>(dist_type, n, interval.first, interval.second);
+	const std::vector<double> Y = apply_func(X, lambda);
+	const std::vector<double> xx = of_type<double>(alfi::dist::Type::UNIFORM, nn, interval.first, interval.second);
+	const alfi::spline::LinearSpline<> spline(X, Y);
+	std::vector<double> result;
+	for (auto _ : state) {
+		result = spline.eval(xx);
+		benchmark::DoNotOptimize(result);
+		benchmark::ClobberMemory();
+	}
+	const std::vector<double> expected = apply_func(xx, lambda);
+	add_error_metrics(state, result, expected);
+}
+BENCHMARK(BM_linear_spline_values)
+	->ArgsProduct({
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(funcs_and_ints.size()) - 1, 1),
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(dists.size()) - 1, 1),
+		concat_vectors<int64_t>(benchmark::CreateRange(8, 32, 2), benchmark::CreateRange(1 << 6, 1 << 21, 1 << 3)),
+		{nn},
+	})
+	->ArgNames({"func", "dist", "n", "nn"});
+
+BENCHMARK_MAIN();

--- a/benches/spline/bench_quadratic.cpp
+++ b/benches/spline/bench_quadratic.cpp
@@ -1,0 +1,68 @@
+#include <benchmark/benchmark.h>
+
+#include <ALFI/spline/quadratic.h>
+
+#include "../bench_utils.h"
+#include "../bench_data.h"
+
+const std::vector<alfi::spline::QuadraticSpline<>::Type> quadratic_spline_types = {
+	alfi::spline::QuadraticSpline<>::Types::SemiNotAKnot{},
+	alfi::spline::QuadraticSpline<>::Types::SemiNatural{},
+	alfi::spline::QuadraticSpline<>::Types::SemiSemi{},
+};
+
+static void BM_quadratic_spline(benchmark::State& state) {
+	const auto& [func_name, lambda] = funcs_and_ints[state.range(0)].first;
+	const auto& interval = funcs_and_ints[state.range(0)].second;
+	const auto& dist_type = dists[state.range(1)];
+	const auto& n = state.range(2);
+	const auto& type = quadratic_spline_types[state.range(3)];
+	const std::vector<double> X = of_type<double>(dist_type, n, interval.first, interval.second);
+	const std::vector<double> Y = apply_func(X, lambda);
+	alfi::spline::QuadraticSpline<> spline;
+	for (auto _ : state) {
+		spline = alfi::spline::QuadraticSpline<>(X, Y, type);
+		benchmark::DoNotOptimize(spline);
+		benchmark::ClobberMemory();
+	}
+}
+BENCHMARK(BM_quadratic_spline)
+	->ArgsProduct({
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(funcs_and_ints.size()) - 1, 1),
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(dists.size()) - 1, 1),
+		benchmark::CreateRange(1 << 6, 1 << 21, 1 << 3),
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(quadratic_spline_types.size()) - 1, 1),
+	})
+	->ArgNames({"func", "dist", "n", "type"});
+
+static void BM_quadratic_spline_values(benchmark::State& state) {
+	const auto& [func_name, lambda] = funcs_and_ints[state.range(0)].first;
+	const auto& interval = funcs_and_ints[state.range(0)].second;
+	const auto& dist_type = dists[state.range(1)];
+	const auto& n = state.range(2);
+	const auto& nn = state.range(3);
+	const auto& type = quadratic_spline_types[state.range(4)];
+	const std::vector<double> X = of_type<double>(dist_type, n, interval.first, interval.second);
+	const std::vector<double> Y = apply_func(X, lambda);
+	const std::vector<double> xx = of_type<double>(alfi::dist::Type::UNIFORM, nn, interval.first, interval.second);
+	const alfi::spline::QuadraticSpline<> spline(X, Y, type);
+	std::vector<double> result;
+	for (auto _ : state) {
+		result = spline.eval(xx);
+		benchmark::DoNotOptimize(result);
+		benchmark::ClobberMemory();
+	}
+	const std::vector<double> expected = apply_func(xx, lambda);
+	add_error_metrics(state, result, expected);
+}
+BENCHMARK(BM_quadratic_spline_values)
+	->ArgsProduct({
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(funcs_and_ints.size()) - 1, 1),
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(dists.size()) - 1, 1),
+		concat_vectors<int64_t>(benchmark::CreateRange(8, 32, 2), benchmark::CreateRange(1 << 6, 1 << 21, 1 << 3)),
+		{nn},
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(quadratic_spline_types.size()) - 1, 1),
+	})
+	->ArgNames({"func", "dist", "n", "nn", "type"});
+
+BENCHMARK_MAIN();

--- a/benches/spline/bench_step.cpp
+++ b/benches/spline/bench_step.cpp
@@ -1,0 +1,68 @@
+#include <benchmark/benchmark.h>
+
+#include <ALFI/spline/step.h>
+
+#include "../bench_utils.h"
+#include "../bench_data.h"
+
+const std::vector<alfi::spline::StepSpline<>::Type> step_spline_types = {
+	alfi::spline::StepSpline<>::Types::Left{},
+	alfi::spline::StepSpline<>::Types::Middle{},
+	alfi::spline::StepSpline<>::Types::Right{},
+};
+
+static void BM_step_spline(benchmark::State& state) {
+	const auto& [func_name, lambda] = funcs_and_ints[state.range(0)].first;
+	const auto& interval = funcs_and_ints[state.range(0)].second;
+	const auto& dist_type = dists[state.range(1)];
+	const auto& n = state.range(2);
+	const auto& type = step_spline_types[state.range(3)];
+	const std::vector<double> X = of_type<double>(dist_type, n, interval.first, interval.second);
+	const std::vector<double> Y = apply_func(X, lambda);
+	alfi::spline::StepSpline<> spline;
+	for (auto _ : state) {
+		spline = alfi::spline::StepSpline<>(X, Y, type);
+		benchmark::DoNotOptimize(spline);
+		benchmark::ClobberMemory();
+	}
+}
+BENCHMARK(BM_step_spline)
+	->ArgsProduct({
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(funcs_and_ints.size()) - 1, 1),
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(dists.size()) - 1, 1),
+		benchmark::CreateRange(1 << 6, 1 << 21, 1 << 3),
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(step_spline_types.size()) - 1, 1),
+	})
+	->ArgNames({"func", "dist", "n", "type"});
+
+static void BM_step_spline_values(benchmark::State& state) {
+	const auto& [func_name, lambda] = funcs_and_ints[state.range(0)].first;
+	const auto& interval = funcs_and_ints[state.range(0)].second;
+	const auto& dist_type = dists[state.range(1)];
+	const auto& n = state.range(2);
+	const auto& nn = state.range(3);
+	const auto& type = step_spline_types[state.range(4)];
+	const std::vector<double> X = of_type<double>(dist_type, n, interval.first, interval.second);
+	const std::vector<double> Y = apply_func(X, lambda);
+	const std::vector<double> xx = of_type<double>(alfi::dist::Type::UNIFORM, nn, interval.first, interval.second);
+	const alfi::spline::StepSpline<> spline(X, Y, type);
+	std::vector<double> result;
+	for (auto _ : state) {
+		result = spline.eval(xx);
+		benchmark::DoNotOptimize(result);
+		benchmark::ClobberMemory();
+	}
+	const std::vector<double> expected = apply_func(xx, lambda);
+	add_error_metrics(state, result, expected);
+}
+BENCHMARK(BM_step_spline_values)
+	->ArgsProduct({
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(funcs_and_ints.size()) - 1, 1),
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(dists.size()) - 1, 1),
+		concat_vectors<int64_t>(benchmark::CreateRange(8, 32, 2), benchmark::CreateRange(1 << 6, 1 << 21, 1 << 3)),
+		{nn},
+		benchmark::CreateDenseRange(0, static_cast<int64_t>(step_spline_types.size()) - 1, 1),
+	})
+	->ArgNames({"func", "dist", "n", "nn", "type"});
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
### Types of changes
- Benchmarking
- Dependency version updates
- Configuration (project, CD)

Related: #49

### Description
1. Dependencies:
	- Added submodule `https://github.com/google/benchmark` to `benches/deps/benchmark`.

2. Benchmarks:
	- Introduced a suite of benchmarks for various interpolation methods:
		- Polynomial coefficient evaluation and interpolation (Lagrange, Improved Lagrange, Newton) in `benches/poly`;
		- Barycentric formula interpolation in `benches/misc`;
		- Step, Linear, Quadratic, and Cubic spline interpolation benchmarks in `benches/spline`.

3. CI:
	- Updated `.github/workflows/clang-tidy.yml` to include files from the `benches` directory in static analysis.

4. IDE Configuration:
	- Added run configurations for benchmarks in `.idea/runConfigurations`, specifying flags `--benchmark_color=yes --benchmark_counters_tabular=yes`.