### PR TITLE
ci(clang-tidy): Disabled unnecessary checks related to compiler options

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -39,7 +39,9 @@ jobs:
         run: |
           set -o pipefail
           files=$(find ALFI examples tests benches -path 'ALFI/*.h' -o -path 'examples/*.cpp' -o -path 'tests/*.cpp' -o -path 'benches/*.cpp' ! -path '*deps/*')
-          clang-tidy -p ${{ env.BUILD_DIR }} --use-color $files 2>&1 |
+          clang-tidy -p ${{ env.BUILD_DIR }} --use-color $files 2>&1 \
+              --extra-arg=-Wno-unknown-warning-option \
+              --extra-arg=-Wno-unused-command-line-argument |
             sed "s|${{ github.workspace }}/||g" |
             tee >(ansi2txt | clang-tidy-sarif > results.sarif)
 


### PR DESCRIPTION
### Types of changes
- Configuration (CI/CD)

Related: #46 #58

### Description
Clang-Tidy started failing due to the `-Wno-lto-type-mismatch` and `-s` options for the Google Benchmark object files.
This is strange, as it didn't fail right after the benchmarks were implemented, and they haven't been changed since, especially especially considering Clang-Tidy should ignore the source files for these object files.

This commit adds the `-Wno-unknown-warning-option` and `-Wno-unused-command-line-argument` options to Clang-Tidy.

### Additional information
1.  Logs from commit bb771dd9e1d780c7269ae2def5f2fff6e9e59ae8 (bench: Introduced benchmarks (https://github.com/ALFI-lib/ALFI/pull/58)): 
[logs_36137402605.zip](https://github.com/user-attachments/files/19528560/logs_36137402605.zip)
2. Logs from commit cab8b261a0160c3e58d5aff9d4021085ed0832c6 (bench(spline): Implemented benchmarks for PolyEqvSpline (https://github.com/ALFI-lib/ALFI/pull/63)):
[logs_36402007344.zip](https://github.com/user-attachments/files/19528573/logs_36402007344.zip)
3.  Logs from the *same* commit cab8b261a0160c3e58d5aff9d4021085ed0832c6, but from a different repository and 2 days later:
[logs_36439522113.zip](https://github.com/user-attachments/files/19528579/logs_36439522113.zip)