### PR TITLE
Refined epsilon handling: consider boundary values as equal

### DIFF
--- a/ALFI/ALFI/util/linalg.h
+++ b/ALFI/ALFI/util/linalg.h
@@ -45,7 +45,7 @@ namespace alfi::util::linalg {
 					i_max = k;
 				}
 			}
-			if (max_a < epsilon) {
+			if (max_a <= epsilon) {
 				std::cerr << "Error in function " << __FUNCTION__ << ": Matrix A is degenerate. Returning an empty array..." << std::endl;
 				return {};
 			}

--- a/ALFI/ALFI/util/numeric.h
+++ b/ALFI/ALFI/util/numeric.h
@@ -7,6 +7,6 @@
 namespace alfi::util::numeric {
 	template <typename Number = DefaultNumber>
 	bool are_equal(Number a, Number b, Number epsilon = std::numeric_limits<Number>::epsilon()) {
-		return std::abs(a - b) < epsilon || std::abs(a - b) < std::max(std::abs(a), std::abs(b)) * epsilon;
+		return std::abs(a - b) <= epsilon || std::abs(a - b) <= std::max(std::abs(a), std::abs(b)) * epsilon;
 	}
 }


### PR DESCRIPTION
### Types of changes
- Something between a small fix and a feature, maybe refactoring
- Dependency version updates

Related: #7 #13 https://github.com/ALFI-lib/test_data/pull/14

### Description
- Changed epsilon comparisons from "<" to "<=" so values exactly at epsilon are treated as equal.
- Updated the `tests/test_data` submodule to commit with similar changes.