### PR TITLE
build: Added support for custom compilation flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,14 +9,14 @@ project(ALFI
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic -march=native")
-set(CMAKE_CXX_FLAGS_DEBUG "-g3")
-set(CMAKE_CXX_FLAGS_RELEASE "-g0 -s -O3 -flto=auto -DNDEBUG")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g3 -O2 -flto=auto -DNDEBUG")
-set(CMAKE_CXX_FLAGS_MINSIZEREL "-g0 -s -Oz -flto=auto -DNDEBUG")
-set(CMAKE_CXX_FLAGS_FAST "-g0 -s -Ofast -fno-finite-math-only -flto=auto -DNDEBUG")
-set(CMAKE_CXX_FLAGS_FASTPARALLEL "-g0 -s -Ofast -fno-finite-math-only -flto=auto -fopenmp -DNDEBUG")
-set(CMAKE_CXX_FLAGS_SANITIZE "-g3 -fsanitize=address,leak,undefined")
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic -march=native ${ALFI_EXTRA_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS_DEBUG "-g3 ${ALFI_EXTRA_CXX_FLAGS_DEBUG}")
+set(CMAKE_CXX_FLAGS_RELEASE "-g0 -s -O3 -flto=auto -DNDEBUG ${ALFI_EXTRA_CXX_FLAGS_RELEASE}")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g3 -O2 -flto=auto -DNDEBUG ${ALFI_EXTRA_CXX_FLAGS_RELWITHDEBINFO}")
+set(CMAKE_CXX_FLAGS_MINSIZEREL "-g0 -s -Oz -flto=auto -DNDEBUG ${ALFI_EXTRA_CXX_FLAGS_MINSIZEREL}")
+set(CMAKE_CXX_FLAGS_FAST "-g0 -s -Ofast -fno-finite-math-only -flto=auto -DNDEBUG ${ALFI_EXTRA_CXX_FLAGS_FAST}")
+set(CMAKE_CXX_FLAGS_FASTPARALLEL "-g0 -s -Ofast -fno-finite-math-only -flto=auto -fopenmp -DNDEBUG ${ALFI_EXTRA_CXX_FLAGS_FASTPARALLEL}")
+set(CMAKE_CXX_FLAGS_SANITIZE "-g3 -fsanitize=address,leak,undefined ${ALFI_EXTRA_CXX_FLAGS_SANITIZE}")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 


### PR DESCRIPTION
### Types of changes
- Configuration (build)

Related: #7 #8 #34

### Description
Introduced variables `ALFI_EXTRA_CXX_FLAGS` and `ALFI_EXTRA_CXX_FLAGS_<CONFIG>` for customizing compilation flags in CMake.
This may be used when working with CMake from the terminal or when adding the library as a submodule.